### PR TITLE
[JFR] Remove useless fields of ThreadAllocationStatistics

### DIFF
--- a/src/share/vm/trace/traceevents.xml
+++ b/src/share/vm/trace/traceevents.xml
@@ -891,8 +891,6 @@ Declares a structure type that can be used in other events.
   <event id="ThreadAllocationStatistics" path="java/statistics/thread_allocation" label="Thread Allocation Statistics"
          is_requestable="true">
     <value type="BYTES64" field="allocated" label="Allocated" description="Approximate number of bytes allocated since thread start"/>
-    <value type="BYTES64" field="stackUsed" label="StackUsed" description="The number of bytes used(Virtual Memory) by thread stack"/>
-    <value type="BYTES64" field="stackPhysicalUsed" label="StackPhysicalUsed" description="The number of bytes used(Physical Memory) by thread stack"/>
     <value type="THREAD" field="thread" label="Thread"/>
   </event>
 


### PR DESCRIPTION
Summary:
remove useless fields of ThreadAllocationStatistics

Test Plan: jdk/test/jdk/jfr/event/runtime/TestThreadAllocationEvent.java

Reviewed-by: yfxhust, luchsh

Issue: #5