### PR TITLE
[C2] Backport JDK-8217359: C2 compiler triggers SIGSEGV after transformation in ConvI2LNode::Ideal

### DIFF
--- a/src/share/vm/opto/connode.cpp
+++ b/src/share/vm/opto/connode.cpp
@@ -1083,7 +1083,11 @@ Node *ConvI2LNode::Ideal(PhaseGVN *phase, bool can_reshape) {
     assert(rxlo == (int)rxlo && rxhi == (int)rxhi, "x should not overflow");
     assert(rylo == (int)rylo && ryhi == (int)ryhi, "y should not overflow");
     Node* cx = phase->C->constrained_convI2L(phase, x, TypeInt::make(rxlo, rxhi, widen), NULL);
+    Node* hook = new (phase->C) Node(1);
+    hook->init_req(0, cx);  // Add a use to cx to prevent him from dying
     Node* cy = phase->C->constrained_convI2L(phase, y, TypeInt::make(rylo, ryhi, widen), NULL);
+    hook->del_req(0);  // Just yank bogus edge
+    hook->destruct();
     switch (op) {
     case Op_AddI:  return new (phase->C) AddLNode(cx, cy);
     case Op_SubI:  return new (phase->C) SubLNode(cx, cy);

--- a/test/compiler/c2/Test8217359.java
+++ b/test/compiler/c2/Test8217359.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2019, Huawei Technologies Co. Ltd. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8217359
+ * @summary C2 compiler triggers SIGSEGV after transformation in ConvI2LNode::Ideal
+ *
+ * @run main/othervm -XX:-TieredCompilation
+ *      -XX:CompileCommand=compileonly,compiler.c2.Test8217359::test
+ *      compiler.c2.Test8217359
+ */
+
+package compiler.c2;
+
+public class Test8217359 {
+
+    public static int ival = 0;
+    public static long lsum = 0;
+    public static long lval = 0;
+
+    public static void test() {
+        short s = -25632;
+        float f = 0.512F, f1 = 2.556F;
+        int i6 = 32547, i7 = 9, i8 = -9, i9 = 36, i10 = -223;
+
+        for (i6 = 4; i6 < 182; i6++) {
+            i8 = 1;
+            while (++i8 < 17) {
+                f1 = 1;
+                do {
+                    i7 += (182 + (f1 * f1));
+                } while (++f1 < 1);
+
+                Test8217359.ival += (i8 | Test8217359.ival);
+            }
+        }
+
+        for (i9 = 9; i9 < 100; ++i9) {
+            i10 -= i6;
+            i10 >>= s;
+            i7 += (((i9 * i10) + i6) - Test8217359.lval);
+        }
+
+        lsum += i6 + i7 + i8;
+    }
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 16000; i++) {
+            test();
+        }
+    }
+
+}


### PR DESCRIPTION
Summary: Add a use of the node `cx` to avoid it being destroyed.
Backport from [JDK-8217359](https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8217359).
This patch of OpenJDK is available [here](https://hg.openjdk.java.net/jdk/jdk12/rev/44f41693631f).

Test Plan: test/compiler/c2/Test8217359.java

Reviewed-by: luchsh, kuaiwei

Issue: https://github.com/alibaba/dragonwell8/issues/11