### PR TITLE
[C2] Backport JDK-8010500: Possible null pointer dereference at hotsp…

### DIFF
--- a/src/share/vm/opto/superword.cpp
+++ b/src/share/vm/opto/superword.cpp
@@ -448,6 +448,7 @@ bool SuperWord::ref_is_alignable(SWPointer& p) {
     return true;   // no induction variable
   }
   CountedLoopEndNode* pre_end = get_pre_loop_end(lp()->as_CountedLoop());
+  assert(pre_end != NULL, "we must have a correct pre-loop");
   assert(pre_end->stride_is_con(), "pre loop stride is constant");
   int preloop_stride = pre_end->stride_con();
 
@@ -2050,7 +2051,7 @@ void SuperWord::align_initial_loop_index(MemNode* align_to_ref) {
   CountedLoopNode *main_head = lp()->as_CountedLoop();
   assert(main_head->is_main_loop(), "");
   CountedLoopEndNode* pre_end = get_pre_loop_end(main_head);
-  assert(pre_end != NULL, "");
+  assert(pre_end != NULL, "we must have a correct pre-loop");
   Node *pre_opaq1 = pre_end->limit();
   assert(pre_opaq1->Opcode() == Op_Opaque1, "");
   Opaque1Node *pre_opaq = (Opaque1Node*)pre_opaq1;
@@ -2214,7 +2215,8 @@ CountedLoopEndNode* SuperWord::get_pre_loop_end(CountedLoopNode *cl) {
   if (!p_f->is_IfFalse()) return NULL;
   if (!p_f->in(0)->is_CountedLoopEnd()) return NULL;
   CountedLoopEndNode *pre_end = p_f->in(0)->as_CountedLoopEnd();
-  if (!pre_end->loopnode()->is_pre_loop()) return NULL;
+  CountedLoopNode* loop_node = pre_end->loopnode();
+  if (loop_node == NULL || !loop_node->is_pre_loop()) return NULL;
   return pre_end;
 }
 


### PR DESCRIPTION
Summary:  Added NULL check for loopnode() in get_pre_loop_end()
Backport the fix for JDK-8010500 (https://hg.openjdk.java.net/jdk9/jdk9/hotspot/rev/4e7ee57b57bf) from OpenJDK.

Test Plan: test/compiler/loopopts/superword/TestPreLoop.java

Reviewed-by: kuaiwei, luchsh

Issue: https://github.com/alibaba/dragonwell8/issues/13