### PR TITLE
[Misc] Fix 8202353 patch ported before

### DIFF
--- a/src/os/linux/vm/os_perf_linux.cpp
+++ b/src/os/linux/vm/os_perf_linux.cpp
@@ -904,21 +904,14 @@ int SystemProcessInterface::SystemProcesses::ProcessIterator::current(SystemProc
 }
 
 int SystemProcessInterface::SystemProcesses::ProcessIterator::next_process() {
-  struct dirent* entry;
-
   if (!is_valid()) {
     return OS_ERR;
   }
 
   do {
-      entry = os::readdir(_dir);
-    if (entry == NULL) {
-      // error
-      _valid = false;
-      return OS_ERR;
-    }
+      _entry = os::readdir(_dir);
     if (_entry == NULL) {
-      // reached end
+      // Error or reached end.  Could use errno to distinguish those cases.
       _valid = false;
       return OS_ERR;
     }
@@ -935,11 +928,8 @@ SystemProcessInterface::SystemProcesses::ProcessIterator::ProcessIterator() {
 }
 
 bool SystemProcessInterface::SystemProcesses::ProcessIterator::initialize() {
-  _dir = opendir("/proc");
-  _entry = (struct dirent*)NEW_C_HEAP_ARRAY(char, sizeof(struct dirent) + NAME_MAX + 1, mtInternal);
-  if (NULL == _entry) {
-    return false;
-  }
+  _dir = os::opendir("/proc");
+  _entry = NULL;
   _valid = true;
   next_process();
 
@@ -947,11 +937,8 @@ bool SystemProcessInterface::SystemProcesses::ProcessIterator::initialize() {
 }
 
 SystemProcessInterface::SystemProcesses::ProcessIterator::~ProcessIterator() {
-  if (_entry != NULL) {
-    FREE_C_HEAP_ARRAY(char, _entry, mtInternal);
-  }
   if (_dir != NULL) {
-    closedir(_dir);
+    os::closedir(_dir);
   }
 }
 


### PR DESCRIPTION
[Misc] Fix 8202353 patch ported before

Summary:
Port 8202353 from lastest jdk, in order to fix compatibility of 8u232 api change instead of the origin openjdk8 patch
The openjdk8 8202353 is not the same as the latest patch.
ref: http://hg.openjdk.java.net/jdk/jdk/rev/f605c91e5219

Test Plan:
pass test jdk/jfr/event/os/TestSystemProcess.java, and other jfr tests, for this patch affects jfr only

Reviewed-by: luchsh,sanhong

Issue: https://github.com/alibaba/dragonwell8/issues/71