### PR TITLE
Revert "Revert "[JFR] add support for opto object allocations sampling""

### DIFF
--- a/make/windows/makefiles/vm.make
+++ b/make/windows/makefiles/vm.make
@@ -468,6 +468,9 @@ arguments.obj: $(WorkSpace)\src\share\vm\runtime\arguments.cpp
 {$(COMMONSRC)\share\vm\jfr\writers}.cpp.obj::
         $(CXX) $(CXX_FLAGS) $(CXX_USE_PCH) /c $<
 
+{$(COMMONSRC)\share\vm\jfr\objectprofiler}.cpp.obj::
+        $(CXX) $(CXX_FLAGS) $(CXX_USE_PCH) /c $<
+
 default::
 
 _build_pch_file.obj:

--- a/src/share/vm/gc_interface/allocTracer.hpp
+++ b/src/share/vm/gc_interface/allocTracer.hpp
@@ -25,14 +25,23 @@
 #ifndef SHARE_VM_GC_INTERFACE_ALLOCTRACER_HPP
 #define SHARE_VM_GC_INTERFACE_ALLOCTRACER_HPP
 
-#include "memory/allocation.hpp"
+#include "gc_implementation/shared/gcId.hpp"
 #include "runtime/handles.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 class AllocTracer : AllStatic {
+  private:
+    static void send_opto_array_allocation_event(KlassHandle klass, oop obj,size_t alloc_size, Thread* thread);
+    static void send_opto_instance_allocation_event(KlassHandle klass, oop obj, Thread* thread);
+
   public:
     static void send_allocation_outside_tlab_event(KlassHandle klass, HeapWord* obj, size_t alloc_size, Thread* thread);
     static void send_allocation_in_new_tlab_event(KlassHandle klass, HeapWord* obj, size_t tlab_size, size_t alloc_size, Thread* thread);
     static void send_allocation_requiring_gc_event(size_t size, const GCId& gcId);
+    static void opto_slow_allocation_enter(bool is_array, Thread* thread);
+    static void opto_slow_allocation_leave(bool is_array, Thread* thread);
+    static void send_slow_allocation_event(KlassHandle klass, oop obj,size_t alloc_size, Thread* thread);
+    static void send_opto_fast_allocation_event(KlassHandle klass, oop obj, size_t alloc_size, Thread* thread);
 };
 
 #endif /* SHARE_VM_GC_INTERFACE_ALLOCTRACER_HPP */

--- a/src/share/vm/gc_interface/allocTracer.inline.hpp
+++ b/src/share/vm/gc_interface/allocTracer.inline.hpp
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2019 Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation. Alibaba designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+#ifndef SHARE_VM_GC_INTERFACE_ALLOCTRACER_INLINE_HPP
+#define SHARE_VM_GC_INTERFACE_ALLOCTRACER_INLINE_HPP
+
+#include "gc_implementation/shared/gcId.hpp"
+#include "jfr/jfrEvents.hpp"
+#include "runtime/handles.hpp"
+#include "utilities/globalDefinitions.hpp"
+#include "gc_interface/allocTracer.hpp"
+#if INCLUDE_JFR
+#include "jfr/recorder/service/jfrOptionSet.hpp"
+#include "jfr/objectprofiler/objectProfiler.hpp"
+#endif // INCLUDE_JFR
+
+inline void AllocTracer::opto_slow_allocation_enter(bool is_array, Thread* thread) {
+#if INCLUDE_JFR
+  if (JfrOptionSet::sample_object_allocations() &&
+      ObjectProfiler::enabled()) {
+    assert(thread != NULL, "Invariant");
+    assert(thread->is_Java_thread(), "Invariant");
+    thread->jfr_thread_local()->incr_alloc_count(1);
+    if (is_array) {
+      thread->jfr_thread_local()->set_cached_event_id(JfrOptoArrayObjectAllocationEvent);
+    } else {
+      thread->jfr_thread_local()->set_cached_event_id(JfrOptoInstanceObjectAllocationEvent);
+    }
+  }
+#endif // INCLUDE_JFR
+}
+
+inline void AllocTracer::opto_slow_allocation_leave(bool is_array, Thread* thread) {
+#if INCLUDE_JFR
+#ifndef PRODUCT
+  if (JfrOptionSet::sample_object_allocations()) {
+    JfrThreadLocal* jfr_thread_local = thread->jfr_thread_local();
+    assert(!jfr_thread_local->has_cached_event_id(), "Invariant");
+    assert(jfr_thread_local->alloc_count_until_sample() >= jfr_thread_local->alloc_count(), "Invariant");
+  }
+#endif
+#endif // INCLUDE_JFR
+}
+
+inline void AllocTracer::send_opto_array_allocation_event(KlassHandle klass, oop obj, size_t alloc_size, Thread* thread) {
+  EventOptoArrayObjectAllocation event;
+  if (event.should_commit()) {
+    event.set_objectClass(klass());
+    event.set_address(cast_from_oop<u8>(obj));
+    event.set_allocationSize(alloc_size);
+    event.commit();
+  }
+}
+
+inline void AllocTracer::send_opto_instance_allocation_event(KlassHandle klass, oop obj, Thread* thread) {
+  EventOptoInstanceObjectAllocation event;
+  if (event.should_commit()) {
+    event.set_objectClass(klass());
+    event.set_address(cast_from_oop<u8>(obj));
+    event.commit();
+  }
+}
+
+inline void AllocTracer::send_slow_allocation_event(KlassHandle klass, oop obj, size_t alloc_size, Thread* thread) {
+#if INCLUDE_JFR
+  if (JfrOptionSet::sample_object_allocations()) {
+    assert(thread != NULL, "Illegal parameter: thread is NULL");
+    assert(thread == Thread::current(), "Invariant");
+    if (thread->jfr_thread_local()->has_cached_event_id()) {
+      assert(thread->is_Java_thread(), "Only allow to be called from java thread");
+      jlong alloc_count = thread->jfr_thread_local()->alloc_count();
+      jlong alloc_count_until_sample = thread->jfr_thread_local()->alloc_count_until_sample();
+      assert(alloc_count > 0 || alloc_count <= alloc_count_until_sample, "Invariant");
+      if (alloc_count == alloc_count_until_sample) {
+        JfrEventId event_id = thread->jfr_thread_local()->cached_event_id();
+        if (event_id ==JfrOptoArrayObjectAllocationEvent) {
+          send_opto_array_allocation_event(klass, obj, alloc_size, thread);
+        } else if(event_id == JfrOptoInstanceObjectAllocationEvent) {
+          send_opto_instance_allocation_event(klass, obj, thread);
+        } else {
+            ShouldNotReachHere();
+        }
+        jlong interval = JfrOptionSet::object_allocations_sampling_interval();
+        thread->jfr_thread_local()->incr_alloc_count_until_sample(interval);
+      }
+      thread->jfr_thread_local()->clear_cached_event_id();
+    }
+  }
+#endif // INCLUDE_JFR
+}
+
+inline void AllocTracer::send_opto_fast_allocation_event(KlassHandle klass, oop obj, size_t alloc_size, Thread* thread) {
+#if INCLUDE_JFR
+  assert(JfrOptionSet::sample_object_allocations(), "Invariant");
+  assert(thread != NULL, "Invariant");
+  assert(thread->is_Java_thread(), "Invariant");
+  assert(!thread->jfr_thread_local()->has_cached_event_id(), "Invariant");
+
+  Klass* k = klass();
+  if (k->oop_is_array()) {
+    send_opto_array_allocation_event(klass, obj, alloc_size, thread);
+  } else {
+    send_opto_instance_allocation_event(klass, obj, thread);
+  }
+  jlong interval = JfrOptionSet::object_allocations_sampling_interval();
+  thread->jfr_thread_local()->incr_alloc_count_until_sample(interval);
+#endif // INCLUDE_JFR
+}
+
+#endif /* SHARE_VM_GC_INTERFACE_ALLOCTRACER_INLINE_HPP */

--- a/src/share/vm/gc_interface/collectedHeap.hpp
+++ b/src/share/vm/gc_interface/collectedHeap.hpp
@@ -26,6 +26,7 @@
 #define SHARE_VM_GC_INTERFACE_COLLECTEDHEAP_HPP
 
 #include "gc_interface/gcCause.hpp"
+#include "gc_interface/allocTracer.hpp"
 #include "gc_implementation/shared/gcWhen.hpp"
 #include "memory/allocation.hpp"
 #include "memory/barrierSet.hpp"
@@ -323,6 +324,15 @@ class CollectedHeap : public CHeapObj<mtInternal> {
   inline static void check_array_size(int size, int length, TRAPS);
 
  public:
+  // Implicit Jfr inline methods.
+  static void trace_slow_allocation(KlassHandle klass, oop obj, size_t alloc_size, Thread* thread) {
+    AllocTracer::send_slow_allocation_event(klass, obj, alloc_size, thread);
+  }
+
+  static void trace_allocation_outside_tlab(KlassHandle klass, HeapWord* obj, size_t alloc_size, Thread* thread) {
+    AllocTracer::send_allocation_outside_tlab_event(klass, obj, alloc_size, thread);
+  }
+
   inline static void post_allocation_install_obj_klass(KlassHandle klass,
                                                        oop obj);
 

--- a/src/share/vm/jfr/dcmd/jfrDcmds.hpp
+++ b/src/share/vm/jfr/dcmd/jfrDcmds.hpp
@@ -140,6 +140,11 @@ class JfrRuntimeOptions;
 
 class JfrConfigureFlightRecorderDCmd : public DCmdWithParser {
   friend class JfrOptionSet;
+ private:
+  bool _on_vm_start;
+  void set_on_vm_start(bool on_vm_start) {
+    _on_vm_start = on_vm_start;
+  }
  protected:
   DCmdArgument<char*> _repository_path;
   DCmdArgument<char*> _dump_path;
@@ -150,6 +155,8 @@ class JfrConfigureFlightRecorderDCmd : public DCmdWithParser {
   DCmdArgument<MemorySizeArgument> _memory_size;
   DCmdArgument<MemorySizeArgument> _max_chunk_size;
   DCmdArgument<bool>  _sample_threads;
+  DCmdArgument<bool>  _sample_object_allocations;
+  DCmdArgument<jlong> _object_allocations_sampling_interval;
 
  public:
   JfrConfigureFlightRecorderDCmd(outputStream* output, bool heap);
@@ -168,6 +175,9 @@ class JfrConfigureFlightRecorderDCmd : public DCmdWithParser {
   }
   static int num_arguments();
   virtual void execute(DCmdSource source, TRAPS);
+  bool on_vm_start() const {
+    return _on_vm_start;
+  }
 };
 
 class JfrUnlockCommercialFeaturesDCmd : public DCmd {

--- a/src/share/vm/jfr/jni/jfrJniMethod.hpp
+++ b/src/share/vm/jfr/jni/jfrJniMethod.hpp
@@ -93,6 +93,10 @@ void JNICALL jfr_set_memory_size(JNIEnv* env, jobject jvm, jlong size);
 
 jboolean JNICALL jfr_set_threshold(JNIEnv* env, jobject jvm, jlong event_type_id, jlong thresholdTicks);
 
+void JNICALL jfr_set_sample_object_allocations(JNIEnv* env, jobject jvm,  jboolean sampleAllocations);
+
+void JNICALL jfr_set_object_allocations_sampling_interval(JNIEnv* env, jobject jvm, jlong interval);
+
 void JNICALL jfr_store_metadata_descriptor(JNIEnv* env, jobject jvm, jbyteArray descriptor);
 
 jlong JNICALL jfr_id_for_thread(JNIEnv* env, jobject jvm, jobject t);

--- a/src/share/vm/jfr/jni/jfrJniMethodRegistration.cpp
+++ b/src/share/vm/jfr/jni/jfrJniMethodRegistration.cpp
@@ -62,6 +62,8 @@ JfrJniMethodRegistration::JfrJniMethodRegistration(JNIEnv* env) {
       (char*)"setThreadBufferSize", (char*)"(J)V", (void*)jfr_set_thread_buffer_size,
       (char*)"setMemorySize", (char*)"(J)V", (void*)jfr_set_memory_size,
       (char*)"setThreshold", (char*)"(JJ)Z", (void*)jfr_set_threshold,
+      (char*)"setSampleObjectAllocations", (char*)"(Z)V",(void*)jfr_set_sample_object_allocations,
+      (char*)"setObjectAllocationsSamplingInterval", (char*)"(J)V",(void*)jfr_set_object_allocations_sampling_interval,
       (char*)"storeMetadataDescriptor", (char*)"([B)V", (void*)jfr_store_metadata_descriptor,
       (char*)"getAllowedToDoEventRetransforms", (char*)"()Z", (void*)jfr_allow_event_retransforms,
       (char*)"isAvailable", (char*)"()Z", (void*)jfr_is_available,

--- a/src/share/vm/jfr/leakprofiler/sampling/objectSampler.cpp
+++ b/src/share/vm/jfr/leakprofiler/sampling/objectSampler.cpp
@@ -122,7 +122,7 @@ void ObjectSampler::fill_stacktrace(JfrStackTrace* stacktrace, JavaThread* threa
   assert(stacktrace != NULL, "invariant");
   assert(thread != NULL, "invariant");
   if (JfrEventSetting::has_stacktrace(EventOldObjectSample::eventId)) {
-    JfrStackTraceRepository::fill_stacktrace_for(thread, stacktrace, 0);
+    JfrStackTraceRepository::fill_stacktrace_for(thread, stacktrace, 0, WALK_BY_DEFAULT);
   }
 }
 

--- a/src/share/vm/jfr/metadata/metadata.xml
+++ b/src/share/vm/jfr/metadata/metadata.xml
@@ -575,6 +575,17 @@
     <Field type="ulong" contentType="bytes" name="allocationSize" label="Allocation Size" />
   </Event>
 
+  <Event name="OptoInstanceObjectAllocation" category="Java Application" label="Opto instance object allocation" description="Allocation by Opto jitted method" thread="true" stackTrace="true" startTime="false">
+    <Field type="Class" name="objectClass" label="Object Class" description="Class of allocated instance object"/>
+    <Field type="ulong" contentType="address" name="address" label="Opto Instance Object Allocation Address" description="Address of allocated instance object"/>
+  </Event>
+
+  <Event name="OptoArrayObjectAllocation" category="Java Application" label="Opto array object allocation" description="Array Allocation by Opto jitted method" thread="true" stackTrace="true" startTime="false">
+    <Field type="Class" name="objectClass" label="Object Class" description="Class of allocated array object"/>
+    <Field type="ulong" contentType="address" name="address" label="Opto Array Object Allocation Address" description="Address of allocated instance object"/>
+    <Field type="ulong" contentType="bytes" name="allocationSize" label="Object Size" description="The Array Object Size" />
+  </Event>
+
   <Event name="OldObjectSample" category="Java Virtual Machine, Profiling" label="Old Object Sample" description="A potential memory leak" stackTrace="true" thread="true"
     startTime="false" cutoff="true">
     <Field type="Ticks" name="allocationTime" label="Allocation Time" />
@@ -949,6 +960,7 @@
     <Field type="Symbol" name="name" label="Name" />
     <Field type="Package" name="package" label="Package" />
     <Field type="int" name="modifiers" label="Access Modifiers" />
+    <Field type="int" name="objectSize" label="Object Size" />
   </Type>
 
   <Type name="ClassLoader" label="Java Class Loader">

--- a/src/share/vm/jfr/objectprofiler/objectProfiler.cpp
+++ b/src/share/vm/jfr/objectprofiler/objectProfiler.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2019 Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation. Alibaba designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+#include "precompiled.hpp"
+#include "runtime/vmThread.hpp"
+#include "jfr/objectprofiler/objectProfiler.hpp"
+#include "jfr/utilities/jfrTryLock.hpp"
+#include "jfrfiles/jfrEventClasses.hpp"
+
+volatile jint ObjectProfiler::_enabled = JNI_FALSE;
+bool ObjectProfiler::_sample_instance_obj_alloc  = false;
+bool ObjectProfiler::_sample_array_obj_alloc  = false;
+#ifndef PRODUCT
+volatile int ObjectProfiler::_try_lock = 0;
+#endif
+
+void ObjectProfiler::start(jlong event_id) {
+#ifndef PRODUCT
+  JfrTryLock try_lock(&_try_lock);
+  assert(try_lock.has_lock(), "Not allow contention");
+#endif
+  if (EventOptoInstanceObjectAllocation::eventId == event_id) {
+    if (!_sample_instance_obj_alloc) {
+      _sample_instance_obj_alloc = true;
+    }
+  } else if (EventOptoArrayObjectAllocation::eventId == event_id) {
+    if (!_sample_array_obj_alloc) {
+      _sample_array_obj_alloc = true;
+    }
+  } else {
+    ShouldNotReachHere();
+  }
+  if (enabled() == JNI_TRUE) {
+    return;
+  }
+  OrderAccess::release_store((volatile jint*)&_enabled, JNI_TRUE);
+}
+
+void ObjectProfiler::stop(jlong event_id) {
+#ifndef PRODUCT
+  JfrTryLock try_lock(&_try_lock);
+  assert(try_lock.has_lock(), "Not allow contention");
+#endif
+  if (enabled() == JNI_FALSE) {
+    assert(!_sample_array_obj_alloc && !_sample_instance_obj_alloc, "Invariant");
+    return;
+  }
+  if (EventOptoInstanceObjectAllocation::eventId == event_id) {
+    if (_sample_instance_obj_alloc) {
+      _sample_instance_obj_alloc = false;
+    }
+  } else if (EventOptoArrayObjectAllocation::eventId == event_id) {
+    if (_sample_array_obj_alloc) {
+      _sample_array_obj_alloc = false;
+    }
+  } else {
+    ShouldNotReachHere();
+  }
+  bool should_enable = _sample_array_obj_alloc || _sample_instance_obj_alloc;
+  if (should_enable) {
+    return;
+  }
+  OrderAccess::release_store(&_enabled, JNI_FALSE);
+}
+
+jint ObjectProfiler::enabled() {
+  return OrderAccess::load_acquire((volatile jint*)&_enabled);
+}
+
+void* ObjectProfiler::enabled_flag_address() {
+  return (void*)&_enabled;
+}

--- a/src/share/vm/jfr/objectprofiler/objectProfiler.hpp
+++ b/src/share/vm/jfr/objectprofiler/objectProfiler.hpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2019 Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation. Alibaba designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+#ifndef SHARE_VM_JFR_OBJECTROFILER_OBJECTPROFILER_HPP
+#define SHARE_VM_JFR_OBJECTROFILER_OBJECTPROFILER_HPP
+
+#include "prims/jni.h"
+
+class ObjectProfiler : public AllStatic {
+ private:
+  static volatile jint _enabled;
+  static bool _sample_instance_obj_alloc;
+  static bool _sample_array_obj_alloc;
+#ifndef PRODUCT
+  static volatile int _try_lock;
+#endif
+
+ public:
+  static void start(jlong event_id);
+  static void stop(jlong event_id);
+  static jint enabled();
+  static void* enabled_flag_address();
+};
+
+#endif // SHARE_VM_JFR_OBJECTROFILER_OBJECTPROFILER_HPP

--- a/src/share/vm/jfr/recorder/checkpoint/types/jfrTypeSet.cpp
+++ b/src/share/vm/jfr/recorder/checkpoint/types/jfrTypeSet.cpp
@@ -148,6 +148,16 @@ int write__artifact__klass(JfrCheckpointWriter* writer, JfrArtifactSet* artifact
   writer->write((traceid)CREATE_SYMBOL_ID(symbol_id));
   writer->write(pkg_id);
   writer->write((s4)klass->access_flags().get_flags());
+  if (klass->oop_is_array()) {
+    // The object array size can not be determined statically from klass.
+    // It is determined by the elements length in object layout.
+    // So we put a place holder here to make the event parser ignore it.
+    writer->write((s4)ARRAY_OBJECT_SIZE_PLACE_HOLDER);
+  } else {
+    assert(klass->oop_is_instance(), "invariant");
+    jint instanceSize = ((InstanceKlass*) klass)->size_helper() * HeapWordSize;
+    writer->write((s4)instanceSize);
+  }
   return 1;
 }
 

--- a/src/share/vm/jfr/recorder/jfrEventSetting.cpp
+++ b/src/share/vm/jfr/recorder/jfrEventSetting.cpp
@@ -24,6 +24,7 @@
 
 #include "precompiled.hpp"
 #include "jfr/recorder/jfrEventSetting.inline.hpp"
+#include "jfr/recorder/stacktrace/jfrStackTraceRepository.hpp"
 
 JfrNativeSettings JfrEventSetting::_jvm_event_settings;
 
@@ -51,6 +52,14 @@ void JfrEventSetting::set_enabled(jlong id, bool enabled) {
   JfrEventId event_id = (JfrEventId)id;
   assert(bounds_check_event(event_id), "invariant");
   setting(event_id).enabled = enabled;
+}
+
+StackWalkMode JfrEventSetting::stack_walk_mode(JfrEventId event_id) {
+  if (event_id == JfrOptoArrayObjectAllocationEvent ||
+      event_id == JfrOptoInstanceObjectAllocationEvent) {
+    return WALK_BY_CURRENT_FRAME;
+  }
+  return WALK_BY_DEFAULT;
 }
 
 #ifdef ASSERT

--- a/src/share/vm/jfr/recorder/jfrEventSetting.hpp
+++ b/src/share/vm/jfr/recorder/jfrEventSetting.hpp
@@ -28,6 +28,7 @@
 #include "jni.h"
 #include "jfr/utilities/jfrAllocation.hpp"
 #include "jfrfiles/jfrEventControl.hpp"
+#include "jfr/recorder/stacktrace/jfrStackTraceRepository.hpp"
 
 //
 // Native event settings as an associative array using the event id as key.
@@ -46,6 +47,7 @@ class JfrEventSetting : AllStatic {
   static jlong threshold(JfrEventId event_id);
   static bool set_cutoff(jlong event_id, jlong cutoff_ticks);
   static jlong cutoff(JfrEventId event_id);
+  static StackWalkMode stack_walk_mode(JfrEventId event_id);
   DEBUG_ONLY(static bool bounds_check_event(jlong id);)
 };
 

--- a/src/share/vm/jfr/recorder/service/jfrEvent.hpp
+++ b/src/share/vm/jfr/recorder/service/jfrEvent.hpp
@@ -26,6 +26,7 @@
 #define SHARE_VM_JFR_RECORDER_SERVICE_JFREVENT_HPP
 
 #include "jfr/recorder/jfrEventSetting.inline.hpp"
+#include "jfr/recorder/jfrEventSetting.hpp"
 #include "jfr/recorder/stacktrace/jfrStackTraceRepository.hpp"
 #include "jfr/utilities/jfrTime.hpp"
 #include "jfr/utilities/jfrTypes.hpp"
@@ -176,7 +177,7 @@ class JfrEvent {
         if (tl->has_cached_stack_trace()) {
           writer.write(tl->cached_stack_trace_id());
         } else {
-          writer.write(JfrStackTraceRepository::record(event_thread));
+          writer.write(JfrStackTraceRepository::record(event_thread, 0, JfrEventSetting::stack_walk_mode(T::eventId)));
         }
       } else {
         writer.write<traceid>(0);

--- a/src/share/vm/jfr/recorder/service/jfrOptionSet.hpp
+++ b/src/share/vm/jfr/recorder/service/jfrOptionSet.hpp
@@ -48,6 +48,8 @@ class JfrOptionSet : public AllStatic {
   static jboolean _sample_threads;
   static jboolean _retransform;
   static jboolean _sample_protection;
+  static volatile jboolean _sample_object_allocations;
+  static volatile jlong _object_allocations_sampling_interval;
 
   static bool initialize(Thread* thread);
   static bool configure(TRAPS);
@@ -77,6 +79,10 @@ class JfrOptionSet : public AllStatic {
   static bool allow_event_retransforms();
   static bool sample_protection();
   DEBUG_ONLY(static void set_sample_protection(jboolean protection);)
+  static bool sample_object_allocations();
+  static void set_sample_object_allocations(jboolean value);
+  static jlong object_allocations_sampling_interval();
+  static void set_object_allocations_sampling_interval(jlong value);
 
   static bool parse_flight_recorder_option(const JavaVMOption** option, char* delimiter);
   static bool parse_start_flight_recording_option(const JavaVMOption** option, char* delimiter);

--- a/src/share/vm/jfr/recorder/stacktrace/jfrStackTraceRepository.cpp
+++ b/src/share/vm/jfr/recorder/stacktrace/jfrStackTraceRepository.cpp
@@ -173,7 +173,7 @@ traceid JfrStackTraceRepository::add(const JfrStackTrace& stacktrace) {
   return tid;
 }
 
-traceid JfrStackTraceRepository::record(Thread* thread, int skip /* 0 */) {
+traceid JfrStackTraceRepository::record(Thread* thread, int skip, StackWalkMode mode) {
   assert(thread == Thread::current(), "invariant");
   JfrThreadLocal* const tl = thread->jfr_thread_local();
   assert(tl != NULL, "invariant");
@@ -190,12 +190,12 @@ traceid JfrStackTraceRepository::record(Thread* thread, int skip /* 0 */) {
   }
   assert(frames != NULL, "invariant");
   assert(tl->stackframes() == frames, "invariant");
-  return instance().record_for((JavaThread*)thread, skip,frames, tl->stackdepth());
+  return instance().record_for((JavaThread*)thread, skip, mode, frames, tl->stackdepth());
 }
 
-traceid JfrStackTraceRepository::record_for(JavaThread* thread, int skip, JfrStackFrame *frames, u4 max_frames) {
+traceid JfrStackTraceRepository::record_for(JavaThread* thread, int skip, StackWalkMode mode, JfrStackFrame *frames, u4 max_frames) {
   JfrStackTrace stacktrace(frames, max_frames);
-  return stacktrace.record_safe(thread, skip) ? add(stacktrace) : 0;
+  return stacktrace.record_safe(thread, skip, false, mode) ? add(stacktrace) : 0;
 }
 
 traceid JfrStackTraceRepository::add(const JfrStackTrace* stacktrace, JavaThread* thread) {
@@ -205,7 +205,7 @@ traceid JfrStackTraceRepository::add(const JfrStackTrace* stacktrace, JavaThread
   return add(*stacktrace);
 }
 
-bool JfrStackTraceRepository::fill_stacktrace_for(JavaThread* thread, JfrStackTrace* stacktrace, int skip) {
+bool JfrStackTraceRepository::fill_stacktrace_for(JavaThread* thread, JfrStackTrace* stacktrace, int skip, StackWalkMode mode) {
   assert(thread == Thread::current(), "invariant");
   assert(stacktrace != NULL, "invariant");
   JfrThreadLocal* const tl = thread->jfr_thread_local();
@@ -215,7 +215,7 @@ bool JfrStackTraceRepository::fill_stacktrace_for(JavaThread* thread, JfrStackTr
     stacktrace->set_hash(cached_stacktrace_hash);
     return true;
   }
-  return stacktrace->record_safe(thread, skip, true);
+  return stacktrace->record_safe(thread, skip, true, mode);
 }
 
 size_t JfrStackTraceRepository::write_impl(JfrChunkWriter& sw, bool clear) {
@@ -363,15 +363,44 @@ void JfrStackTrace::resolve_linenos() const {
   _lineno = true;
 }
 
-bool JfrStackTrace::record_safe(JavaThread* thread, int skip, bool leakp /* false */) {
+bool JfrStackTrace::record_safe(JavaThread* thread, int skip, bool leakp, StackWalkMode mode) {
   assert(SafepointSynchronize::safepoint_safe(thread, thread->thread_state())
          || thread == Thread::current(), "Thread stack needs to be walkable");
-  vframeStream vfs(thread);
+
+  bool success = false;
+  switch(mode) {
+    case WALK_BY_DEFAULT:
+      {
+        vframeStream vfs(thread);
+        success = fill_in(vfs, skip, leakp, mode);
+        break;
+      }
+    case WALK_BY_CURRENT_FRAME:
+      {
+        vframeStream vfs(thread, os::current_frame());
+        success = fill_in(vfs, skip, leakp, mode);
+        break;
+      }
+    default:
+      ShouldNotReachHere();
+  }
+  return success;
+}
+
+bool JfrStackTrace::fill_in(vframeStream& vfs, int skip, bool leakp, StackWalkMode mode) {
   u4 count = 0;
   _reached_root = true;
+  // Indicates whether the top frame is visited in this frames iteration.
+  // Top frame bci may be invalid and fill_in() will fix the top frame bci in a conservative way.
+  bool top_frame_visited = false;
   for(int i = 0; i < skip; i++) {
     if (vfs.at_end()) {
       break;
+    }
+    // The top frame is in skip list.
+    // Mark top_frame_visited to avoid unnecessary top frame bci fixing.
+    if (!top_frame_visited) {
+      top_frame_visited = true;
     }
     vfs.next();
   }
@@ -387,8 +416,25 @@ bool JfrStackTrace::record_safe(JavaThread* thread, int skip, bool leakp /* fals
     int bci = 0;
     if (method->is_native()) {
       type = JfrStackFrame::FRAME_NATIVE;
+      // The top frame is in native.
+      // Mark top_frame_visited to avoid unnecessary top frame bci fixing.
+      if (!top_frame_visited) {
+        top_frame_visited = true;
+      }
     } else {
       bci = vfs.bci();
+      // Hit the top frame and fix bci here.
+      if (!top_frame_visited) {
+        if (mode == WALK_BY_CURRENT_FRAME) {
+          // Only fix opto fast path allocation.
+          // All fast path allocations do not have cached event id.
+          if (!vfs.thread_ref()->jfr_thread_local()->has_cached_event_id()) {
+            assert(vfs.thread_ref()->jfr_thread_local()->has_cached_top_frame_bci(), "Invariant");
+            bci = vfs.thread_ref()->jfr_thread_local()->cached_top_frame_bci();
+          }
+        }
+        top_frame_visited = true;
+      }
     }
     // Can we determine if it's inlined?
     _hash = (_hash << 2) + (unsigned int)(((size_t)mid >> 2) + (bci << 4) + type);

--- a/src/share/vm/jfr/support/jfrFlush.cpp
+++ b/src/share/vm/jfr/support/jfrFlush.cpp
@@ -70,12 +70,12 @@ void jfr_conditional_flush(JfrEventId id, size_t size, Thread* t) {
   }
 }
 
-bool jfr_save_stacktrace(Thread* t) {
+bool jfr_save_stacktrace(Thread* t, StackWalkMode mode) {
   JfrThreadLocal* const tl = t->jfr_thread_local();
   if (tl->has_cached_stack_trace()) {
     return false; // no ownership
   }
-  tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(t));
+  tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(t, 0, mode));
   return true;
 }
 

--- a/src/share/vm/jfr/support/jfrFlush.hpp
+++ b/src/share/vm/jfr/support/jfrFlush.hpp
@@ -27,6 +27,8 @@
 
 #include "jfr/recorder/storage/jfrBuffer.hpp"
 #include "jfr/utilities/jfrTypes.hpp"
+#include "jfr/recorder/jfrEventSetting.hpp"
+#include "jfr/recorder/stacktrace/jfrStackTraceRepository.hpp"
 #include "memory/allocation.hpp"
 
 class Thread;
@@ -43,7 +45,7 @@ class JfrFlush : public StackObj {
 void jfr_conditional_flush(JfrEventId id, size_t size, Thread* t);
 bool jfr_is_event_enabled(JfrEventId id);
 bool jfr_has_stacktrace_enabled(JfrEventId id);
-bool jfr_save_stacktrace(Thread* t);
+bool jfr_save_stacktrace(Thread* t, StackWalkMode mode);
 void jfr_clear_stacktrace(Thread* t);
 
 template <typename Event>
@@ -66,7 +68,7 @@ class JfrConditionalFlushWithStacktrace : public JfrConditionalFlush<Event> {
  public:
   JfrConditionalFlushWithStacktrace(Thread* t) : JfrConditionalFlush<Event>(t), _t(t), _owner(false) {
     if (this->_enabled && Event::has_stacktrace() && jfr_has_stacktrace_enabled(Event::eventId)) {
-      _owner = jfr_save_stacktrace(t);
+      _owner = jfr_save_stacktrace(t, JfrEventSetting::stack_walk_mode(Event::eventId));
     }
   }
   ~JfrConditionalFlushWithStacktrace() {

--- a/src/share/vm/jfr/support/jfrStackTraceMark.cpp
+++ b/src/share/vm/jfr/support/jfrStackTraceMark.cpp
@@ -24,6 +24,7 @@
 
 #include "precompiled.hpp"
 #include "jfr/recorder/jfrEventSetting.inline.hpp"
+#include "jfr/recorder/jfrEventSetting.hpp"
 #include "jfr/recorder/stacktrace/jfrStackTraceRepository.hpp"
 #include "jfr/support/jfrStackTraceMark.hpp"
 #include "jfr/support/jfrThreadLocal.hpp"
@@ -35,7 +36,7 @@ JfrStackTraceMark::JfrStackTraceMark() : _t(Thread::current()), _previous_id(0),
     _previous_id = tl->cached_stack_trace_id();
     _previous_hash = tl->cached_stack_trace_hash();
   }
-  tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(Thread::current()));
+  tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(Thread::current(), 0, WALK_BY_DEFAULT));
 }
 
 JfrStackTraceMark::JfrStackTraceMark(Thread* t) : _t(t), _previous_id(0), _previous_hash(0) {
@@ -44,7 +45,7 @@ JfrStackTraceMark::JfrStackTraceMark(Thread* t) : _t(t), _previous_id(0), _previ
     _previous_id = tl->cached_stack_trace_id();
     _previous_hash = tl->cached_stack_trace_hash();
   }
-  tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(t));
+  tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(t, 0, WALK_BY_DEFAULT));
 }
 
 JfrStackTraceMark::JfrStackTraceMark(JfrEventId eventId) : _t(NULL), _previous_id(0), _previous_hash(0) {
@@ -55,7 +56,8 @@ JfrStackTraceMark::JfrStackTraceMark(JfrEventId eventId) : _t(NULL), _previous_i
       _previous_id = tl->cached_stack_trace_id();
       _previous_hash = tl->cached_stack_trace_hash();
     }
-    tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(_t));
+    StackWalkMode mode = JfrEventSetting::stack_walk_mode(eventId);
+    tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(_t, 0, mode));
   }
 }
 
@@ -67,7 +69,8 @@ JfrStackTraceMark::JfrStackTraceMark(JfrEventId eventId, Thread* t) : _t(NULL), 
       _previous_id = tl->cached_stack_trace_id();
       _previous_hash = tl->cached_stack_trace_hash();
     }
-    tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(_t));
+    StackWalkMode mode = JfrEventSetting::stack_walk_mode(eventId);
+    tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(_t, 0, mode));
   }
 }
 

--- a/src/share/vm/jfr/support/jfrThreadLocal.cpp
+++ b/src/share/vm/jfr/support/jfrThreadLocal.cpp
@@ -55,7 +55,11 @@ JfrThreadLocal::JfrThreadLocal() :
   _stack_trace_hash(0),
   _stackdepth(0),
   _entering_suspend_flag(0),
-  _dead(false) {}
+  _dead(false),
+  _cached_top_frame_bci(max_jint),
+  _alloc_count(0),
+  _alloc_count_until_sample(1),
+  _cached_event_id(MaxJfrEventId) {}
 
 u8 JfrThreadLocal::add_data_lost(u8 value) {
   _data_lost += value;

--- a/src/share/vm/jfr/support/jfrTraceIdExtension.hpp
+++ b/src/share/vm/jfr/support/jfrTraceIdExtension.hpp
@@ -78,4 +78,24 @@ class JfrTraceFlag {
     return _trace_flags.flags_addr();              \
   }
 
+#define ARRAY_OBJECT_SIZE_PLACE_HOLDER 0x1111baba
+
+#define TRACE_OPTO_SLOW_ALLOCATION_ENTER(is_array, thread) \
+  AllocTracer::opto_slow_allocation_enter(is_array, thread)
+
+#define TRACE_OPTO_SLOW_ALLOCATION_LEAVE(is_array, thread) \
+  AllocTracer::opto_slow_allocation_leave(is_array, thread)
+
+#define TRACE_SLOW_ALLOCATION(klass, obj, alloc_size, thread) \
+  AllocTracer::send_slow_allocation_event(klass, obj, alloc_size, thread)
+
+#define TRACE_DEFINE_THREAD_ALLOC_COUNT_OFFSET \
+  static ByteSize alloc_count_offset() { return in_ByteSize(offset_of(JfrThreadLocal, _alloc_count)); }
+#define TRACE_THREAD_ALLOC_COUNT_OFFSET \
+  (JfrThreadLocal::alloc_count_offset() + Thread::jfr_thread_local_offset())
+#define TRACE_DEFINE_THREAD_ALLOC_COUNT_UNTIL_SAMPLE_OFFSET \
+  static ByteSize alloc_count_until_sample_offset() { return in_ByteSize(offset_of(JfrThreadLocal, _alloc_count_until_sample)); }
+#define TRACE_THREAD_ALLOC_COUNT_UNTIL_SAMPLE_OFFSET \
+  (JfrThreadLocal::alloc_count_until_sample_offset() + Thread::jfr_thread_local_offset())
+
 #endif // SHARE_VM_JFR_SUPPORT_JFRTRACEIDEXTENSION_HPP

--- a/src/share/vm/opto/macro.hpp
+++ b/src/share/vm/opto/macro.hpp
@@ -61,7 +61,11 @@ private:
     return n;
   }
   void set_eden_pointers(Node* &eden_top_adr, Node* &eden_end_adr);
+  Node* load( Node* ctl, Node* mem, Node* base, int offset,
+                   const Type* value_type, BasicType bt, MemNode::MemOrd mo);
   Node* make_load( Node* ctl, Node* mem, Node* base, int offset,
+                   const Type* value_type, BasicType bt);
+  Node* make_load_acquire( Node* ctl, Node* mem, Node* base, int offset,
                    const Type* value_type, BasicType bt);
   Node* make_store(Node* ctl, Node* mem, Node* base, int offset,
                    Node* value, BasicType bt);
@@ -118,6 +122,10 @@ private:
                             Node*& needgc_false, Node*& contended_phi_rawmem,
                             Node* old_eden_top, Node* new_eden_top,
                             Node* length);
+
+  //JFR tracing
+  void jfr_sample_fast_object_allocation(AllocateNode* alloc, Node* fast_oop, 
+                                         Node*& fast_oop_ctrl, Node*& fast_oop_rawmem);
 
 public:
   PhaseMacroExpand(PhaseIterGVN &igvn) : Phase(Macro_Expand), _igvn(igvn), _has_locks(false) {

--- a/src/share/vm/opto/runtime.hpp
+++ b/src/share/vm/opto/runtime.hpp
@@ -179,6 +179,8 @@ public:
   static void complete_monitor_locking_C(oopDesc* obj, BasicLock* lock, JavaThread* thread);
   static void complete_monitor_unlocking_C(oopDesc* obj, BasicLock* lock);
 
+  // JFR support
+  static void jfr_fast_object_alloc_C(oopDesc* obj, jint bci, JavaThread* thread);
 private:
 
   // Implicit exception support
@@ -338,6 +340,9 @@ private:
 # ifdef ENABLE_ZAP_DEAD_LOCALS
   static const TypeFunc* zap_dead_locals_Type();
 # endif
+
+  // JFR support
+  static const TypeFunc* jfr_fast_object_alloc_Type();
 
  private:
  static NamedCounter * volatile _named_counters;

--- a/src/share/vm/precompiled/precompiled.hpp
+++ b/src/share/vm/precompiled/precompiled.hpp
@@ -97,6 +97,8 @@
 # include "gc_interface/collectedHeap.hpp"
 # include "gc_interface/collectedHeap.inline.hpp"
 # include "gc_interface/gcCause.hpp"
+# include "gc_interface/allocTracer.hpp"
+# include "gc_interface/allocTracer.inline.hpp"
 # include "interpreter/abstractInterpreter.hpp"
 # include "interpreter/bytecode.hpp"
 # include "interpreter/bytecodeHistogram.hpp"

--- a/src/share/vm/runtime/vframe.hpp
+++ b/src/share/vm/runtime/vframe.hpp
@@ -367,6 +367,8 @@ class vframeStream : public vframeStreamCommon {
     }
   }
 
+  Thread *& thread_ref()    { return (Thread *&)_thread; }
+
   // top_frame may not be at safepoint, start with sender
   vframeStream(JavaThread* thread, frame top_frame, bool stop_at_java_call_stub = false);
 };


### PR DESCRIPTION
This reverts commit 6585eb9ceefe7395469fdf618514149b368bc34b.