### PR TITLE
[JFR] Added SafepointStatistics and HugeObjectAllocationSample Events

### DIFF
--- a/src/share/vm/gc_interface/allocTracer.cpp
+++ b/src/share/vm/gc_interface/allocTracer.cpp
@@ -40,6 +40,14 @@ void AllocTracer::send_allocation_outside_tlab_event(KlassHandle klass, HeapWord
     event.set_allocationSize(alloc_size);
     event.commit();
   }
+  if (alloc_size >= HugeObjectAllocationThreshold) {
+    EventHugeObjectAllocationSample hoas_event;
+    if (hoas_event.should_commit()) {
+      hoas_event.set_objectClass(klass());
+      hoas_event.set_allocationSize(alloc_size);
+      hoas_event.commit();
+    }
+  }
 }
 
 void AllocTracer::send_allocation_in_new_tlab_event(KlassHandle klass, HeapWord* obj, size_t tlab_size, size_t alloc_size, Thread* thread) {

--- a/src/share/vm/jfr/metadata/metadata.xml
+++ b/src/share/vm/jfr/metadata/metadata.xml
@@ -512,6 +512,15 @@
     <Field type="int" name="fullCount" label="Full Count" />
   </Event>
 
+  <Event name="SafepointStatistics" category="Java Virtual Machine, Runtime, Safepoint" label="Safepoint Statistics" description="Safepointing Statistics" thread="false" startTime="false" period="everyChunk" experimental="true">
+    <Field type="long" name="totalCount" label="Total Count"/>
+    <Field type="long" contentType="millis" name="syncTime" label="Total Sync Time"/>
+    <Field type="long" contentType="millis" name="safepointTime" label="Total Safepoint Time"/>
+    <Field type="long" contentType="millis" name="applicationTime" label="Total Application Time"/>
+    <Field type="long" contentType="millis" name="maxSyncTime" label="Max Sync Time"/>
+    <Field type="long" contentType="millis" name="maxVMOperatoinTime" label="Max VM Operation Time"/>
+  </Event>
+
   <Event name="SafepointBegin" category="Java Virtual Machine, Runtime, Safepoint" label="Safepoint Begin" description="Safepointing begin" thread="true">
     <Field type="int" name="safepointId" label="Safepoint Identifier" relation="SafepointId" />
     <Field type="int" name="totalThreadCount" label="Total Threads" description="The total number of threads at the start of safe point" />
@@ -573,6 +582,11 @@
     thread="true" stackTrace="true" startTime="false">
     <Field type="Class" name="objectClass" label="Object Class" description="Class of allocated object" />
     <Field type="ulong" contentType="bytes" name="allocationSize" label="Allocation Size" />
+  </Event>
+
+  <Event name="HugeObjectAllocationSample" category="Java Application" label="Huge Object Allocation Sample" description="Huge Object Allocation Sample" thread="true" stackTrace="true" startTime="false" experimental="true">
+    <Field type="Class" name="objectClass" label="Object Class" description="Class of allocated object"/>
+    <Field type="ulong" contentType="bytes" name="allocationSize" label="Allocation Size"/>
   </Event>
 
   <Event name="OptoInstanceObjectAllocation" category="Java Application" label="Opto instance object allocation" description="Allocation by Opto jitted method" thread="true" stackTrace="true" startTime="false">

--- a/src/share/vm/jfr/periodic/jfrPeriodic.cpp
+++ b/src/share/vm/jfr/periodic/jfrPeriodic.cpp
@@ -55,6 +55,7 @@
 #include "runtime/vmThread.hpp"
 #include "services/classLoadingService.hpp"
 #include "services/management.hpp"
+#include "services/runtimeService.hpp"
 #include "services/threadService.hpp"
 #include "utilities/exceptions.hpp"
 #include "utilities/globalDefinitions.hpp"
@@ -556,5 +557,16 @@ TRACE_REQUEST_FUNC(CodeSweeperConfiguration) {
   EventCodeSweeperConfiguration event;
   event.set_sweeperEnabled(MethodFlushing);
   event.set_flushingEnabled(UseCodeCacheFlushing);
+  event.commit();
+}
+
+TRACE_REQUEST_FUNC(SafepointStatistics) {
+  EventSafepointStatistics event;
+  event.set_totalCount(RuntimeService::safepoint_count());
+  event.set_syncTime(RuntimeService::safepoint_sync_time_ms());
+  event.set_safepointTime(RuntimeService::safepoint_time_ms());
+  event.set_applicationTime(RuntimeService::application_time_ms());
+  event.set_maxSyncTime(SafepointSynchronize::max_sync_time_ms());
+  event.set_maxVMOperatoinTime(SafepointSynchronize::max_vmop_time_ms());
   event.commit();
 }

--- a/src/share/vm/runtime/globals_ext.hpp
+++ b/src/share/vm/runtime/globals_ext.hpp
@@ -132,6 +132,10 @@
                                                                             \
   manageable(bool, PrintThreadCoroutineInfo, false,                         \
           "print the park/unpark information for thread coroutine")         \
+                                                                            \
+  manageable(uintx, HugeObjectAllocationThreshold, 128*M,                   \
+          "The size of the used heap of the instance must occupy to "       \
+          "generate a jfr event")                                           \
   //add new AJVM specific flags here
 
 

--- a/src/share/vm/runtime/safepoint.hpp
+++ b/src/share/vm/runtime/safepoint.hpp
@@ -188,6 +188,14 @@ public:
   static address address_of_state()                        { return (address)&_state; }
 
   static address safepoint_counter_addr()                  { return (address)&_safepoint_counter; }
+
+  static jlong max_sync_time_ms() {
+    return nanos_to_millis(_max_sync_time);
+  }
+
+  static jlong max_vmop_time_ms() {
+    return nanos_to_millis(_max_vmop_time);
+  }
 };
 
 // State class for a thread suspended at a safepoint

--- a/src/share/vm/utilities/globalDefinitions.hpp
+++ b/src/share/vm/utilities/globalDefinitions.hpp
@@ -219,6 +219,10 @@ const int NANOUNITS     = 1000000000;   // nano units per base unit
 const jlong NANOSECS_PER_SEC      = CONST64(1000000000);
 const jint  NANOSECS_PER_MILLISEC = 1000000;
 
+inline int64_t nanos_to_millis(int64_t nanos) {
+  return nanos / NANOSECS_PER_MILLISEC;
+}
+
 // Proper units routines try to maintain at least three significant digits.
 // In worst case, it would print five significant digits with lower prefix.
 // G is close to MAX_SIZE on 32-bit platforms, so its product can easily overflow,


### PR DESCRIPTION
Summary:
SafepointStatistics is a periodic event, both events are experimental
now and disbaled by default

Test Plan:
jdk/test/jdk/jfr/event/runtime/TestSafepointEvents.java
jdk/test/jdk/jfr/event/compiler/TestHugeObjectAllocationSample.java
jdk/test/jdk/jfr/event/metadata/TestLookForUntestedEvents.java

Reviewed-by: kuaiwei

Issue: https://github.com/alibaba/dragonwell8/issues/116