### PR TITLE
[Backport] 8237499: JFR: Include stack trace in the ThreadStart event

### DIFF
--- a/src/share/vm/jfr/metadata/metadata.xml
+++ b/src/share/vm/jfr/metadata/metadata.xml
@@ -26,8 +26,9 @@
 
 <Metadata>
 
-  <Event name="ThreadStart" category="Java Application" label="Java Thread Start" thread="true" startTime="false">
-    <Field type="Thread" name="thread" label="Java Thread" />
+  <Event name="ThreadStart" category="Java Application" label="Java Thread Start" thread="true" startTime="false" stackTrace="true">
+    <Field type="Thread" name="thread" label="New Java Thread" />
+    <Field type="Thread" name="parentThread" label="Parent Java Thread" />
   </Event>
 
   <Event name="ThreadEnd" category="Java Application" label="Java Thread End" thread="true" startTime="false">

--- a/src/share/vm/jfr/support/jfrThreadLocal.hpp
+++ b/src/share/vm/jfr/support/jfrThreadLocal.hpp
@@ -52,6 +52,7 @@ class JfrThreadLocal {
   volatile jint _entering_suspend_flag;
   bool _excluded;
   bool _dead;
+  traceid _parent_trace_id;
   // Jfr callstack collection relies on vframeStream.
   // But the bci of top frame can not be determined by vframeStream in some scenarios.
   // For example, in the opto CallLeafNode runtime call of
@@ -147,6 +148,10 @@ class JfrThreadLocal {
 
   void set_thread_id(traceid thread_id) {
     _trace_id = thread_id;
+  }
+
+  traceid parent_thread_id() const {
+    return _parent_trace_id;
   }
 
   void set_cached_stack_trace_id(traceid id, unsigned int hash = 0) {

--- a/src/share/vm/prims/jni.cpp
+++ b/src/share/vm/prims/jni.cpp
@@ -5026,11 +5026,14 @@ static void post_thread_start_event(const JavaThread* jt) {
   if (event.should_commit()) {
     event.set_thread(JFR_THREAD_ID(jt));
     event.set_parentThread((traceid)0);
+#if INCLUDE_JFR
     if (EventThreadStart::is_stacktrace_enabled()) {
       jt->jfr_thread_local()->set_cached_stack_trace_id((traceid)0);
       event.commit();
       jt->jfr_thread_local()->clear_cached_stack_trace();
-    } else {
+    } else
+#endif
+    {
       event.commit();
     }
   }

--- a/src/share/vm/prims/jni.cpp
+++ b/src/share/vm/prims/jni.cpp
@@ -5025,7 +5025,14 @@ static void post_thread_start_event(const JavaThread* jt) {
   EventThreadStart event;
   if (event.should_commit()) {
     event.set_thread(JFR_THREAD_ID(jt));
-    event.commit();
+    event.set_parentThread((traceid)0);
+    if (EventThreadStart::is_stacktrace_enabled()) {
+      jt->jfr_thread_local()->set_cached_stack_trace_id((traceid)0);
+      event.commit();
+      jt->jfr_thread_local()->clear_cached_stack_trace();
+    } else {
+      event.commit();
+    }
   }
 }
 

--- a/src/share/vm/prims/jvm.cpp
+++ b/src/share/vm/prims/jvm.cpp
@@ -101,6 +101,7 @@
 #endif // INCLUDE_ALL_GCS
 
 #include <errno.h>
+#include <jfr/recorder/jfrRecorder.hpp>
 
 #ifndef USDT2
 HS_DTRACE_PROBE_DECL1(hotspot, thread__sleep__begin, long long);
@@ -3229,6 +3230,15 @@ JVM_ENTRY(void, JVM_StartThread(JNIEnv* env, jobject jthread))
     THROW_MSG(vmSymbols::java_lang_OutOfMemoryError(),
               "unable to create new native thread");
   }
+
+#if INCLUDE_JFR
+  if (JfrRecorder::is_recording() && EventThreadStart::is_enabled() &&
+      EventThreadStart::is_stacktrace_enabled()) {
+    JfrThreadLocal* tl = native_thread->jfr_thread_local();
+    // skip Thread.start() and Thread.start0()
+    tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(thread, 2, WALK_BY_DEFAULT));
+  }
+#endif
 
   Thread::start(native_thread);
 


### PR DESCRIPTION
Summary:

Test Plan: jdk/test/jdk/jfr/event/runtime/TestThreadStartEndEvents.java

Reviewed-by: zhengxiaolinX, yuleil

Issue: https://github.com/alibaba/dragonwell8/issues/127