### PR TITLE
[Wisp] Support threadMxbean in AllThreadAsWisp

### DIFF
--- a/src/share/vm/prims/unsafe.cpp
+++ b/src/share/vm/prims/unsafe.cpp
@@ -1503,17 +1503,6 @@ JVM_ENTRY(jboolean, CoroutineSupport_stealCoroutine(JNIEnv* env, jclass klass, j
   return true;
 JVM_END
 
-JVM_ENTRY (jobjectArray, CoroutineSupport_getCoroutineStack(JNIEnv* env, jclass klass, jlong coroPtr))
-  assert(EnableCoroutine, "pre-condition");
-
-  JvmtiVMObjectAllocEventCollector oam;
-
-  Coroutine* coro = (Coroutine*)coroPtr;
-
-  Handle stacktraces = ThreadService::dump_coroutine_stack_trace(coro, CHECK_NULL);
-  return (jobjectArray)JNIHandles::make_local(env, stacktraces());
-JVM_END
-
 JVM_ENTRY (void, CoroutineSupport_checkAndThrowException0(JNIEnv* env, jclass klass, jlong coroPtr))
   assert(EnableCoroutine, "pre-condition");
   Coroutine* coro = (Coroutine*)coroPtr;
@@ -1880,7 +1869,6 @@ JNINativeMethod coroutine_support_methods[] = {
     {CC"getNextCoroutine",        CC"(J)"COR,         FN_PTR(CoroutineSupport_getNextCoroutine)},
     {CC"moveCoroutine",           CC"(JJ)V",          FN_PTR(CoroutineSupport_moveCoroutine)},
     {CC"markThreadCoroutine",     CC"(J"COBA")V",     FN_PTR(CoroutineSupport_markThreadCoroutine)},
-    {CC"getCoroutineStack",       CC"(J)["STE,        FN_PTR(CoroutineSupport_getCoroutineStack)},
     {CC"checkAndThrowException0", CC"(J)V",           FN_PTR(CoroutineSupport_checkAndThrowException0)},
 };
 

--- a/src/share/vm/runtime/thread.cpp
+++ b/src/share/vm/runtime/thread.cpp
@@ -4299,6 +4299,20 @@ JavaThread* Threads::find_java_thread_from_java_tid(jlong java_tid) {
       java_thread = thread;
       break;
     }
+
+    if (EnableCoroutine) {
+      for (Coroutine* co = thread->coroutine_list()->next();
+          co != thread->coroutine_list(); co = co->next()) {
+        oop wtObj = com_alibaba_wisp_engine_WispTask::get_threadWrapper(co->wisp_task());
+        // wtObj == 0 means coroutine is cached
+        if (!thread->is_exiting() &&
+            wtObj != NULL &&
+            java_tid == java_lang_Thread::thread_id(wtObj)) {
+          co->wisp_thread()->set_threadObj(wtObj);
+          return co->wisp_thread();
+        }
+      }
+    }
   }
   return java_thread;
 }

--- a/src/share/vm/runtime/vm_operations.hpp
+++ b/src/share/vm/runtime/vm_operations.hpp
@@ -42,7 +42,6 @@
   template(Dummy)                                 \
   template(ThreadStop)                            \
   template(ThreadDump)                            \
-  template(CoroutineDump)                         \
   template(PrintThreads)                          \
   template(FindDeadlocks)                         \
   template(ForceSafepoint)                        \
@@ -361,6 +360,7 @@ class VM_ThreadDump : public VM_Operation {
   bool                           _with_locked_synchronizers;
 
   ThreadSnapshot* snapshot_thread(JavaThread* java_thread, ThreadConcurrentLocks* tcl);
+  ThreadSnapshot* snapshot_coroutine(Coroutine* coro, ThreadConcurrentLocks* tcl);
 
  public:
   VM_ThreadDump(ThreadDumpResult* result,
@@ -380,23 +380,6 @@ class VM_ThreadDump : public VM_Operation {
   bool doit_prologue();
   void doit_epilogue();
 };
-
-class VM_CoroutineDump : public VM_Operation {
- private:
-  ThreadDumpResult*              _result;
-  Coroutine *                    _target;
-
-  ThreadSnapshot* snapshot_thread(JavaThread* java_thread, ThreadConcurrentLocks* tcl);
-
- public:
-  VM_CoroutineDump(ThreadDumpResult* result, Coroutine *target);
-
-  VMOp_Type type() const { return VMOp_CoroutineDump; }
-  void doit();
-  bool doit_prologue();
-  void doit_epilogue();
-};
-
 
 class VM_Exit: public VM_Operation {
  private:

--- a/src/share/vm/services/threadService.hpp
+++ b/src/share/vm/services/threadService.hpp
@@ -105,8 +105,6 @@ public:
   static Handle dump_stack_traces(GrowableArray<instanceHandle>* threads,
                                   int num_threads, TRAPS);
 
-  static Handle dump_coroutine_stack_trace(Coroutine *coro, TRAPS);
-
   static void   reset_peak_thread_count();
   static void   reset_contention_count_stat(JavaThread* thread);
   static void   reset_contention_time_stat(JavaThread* thread);
@@ -243,7 +241,7 @@ public:
   ThreadConcurrentLocks* get_concurrent_locks()     { return _concurrent_locks; }
 
   void        dump_stack_at_safepoint(int max_depth, bool with_locked_monitors);
-  void        dump_stack_at_safepoint_for_coroutine(Coroutine *target);
+  void        dump_stack_at_safepoint_for_coroutine(Coroutine *target, int max_depth, bool with_locked_monitors);
   void        set_concurrent_locks(ThreadConcurrentLocks* l) { _concurrent_locks = l; }
   void        oops_do(OopClosure* f);
   void        metadata_do(void f(Metadata*));
@@ -268,7 +266,7 @@ class ThreadStackTrace : public CHeapObj<mtInternal> {
 
   void            add_stack_frame(javaVFrame* jvf);
   void            dump_stack_at_safepoint(int max_depth);
-  void            dump_stack_at_safepoint_for_coroutine(Coroutine *target);
+  void            dump_stack_at_safepoint_for_coroutine(Coroutine *target, int max_depth);
   Handle          allocate_fill_stack_trace_element_array(TRAPS);
   void            oops_do(OopClosure* f);
   void            metadata_do(void f(Metadata*));
@@ -392,6 +390,7 @@ class DeadlockCycle : public CHeapObj<mtInternal> {
 class ThreadsListEnumerator : public StackObj {
 private:
   GrowableArray<instanceHandle>* _threads_array;
+  static bool skipThread(JavaThread* jt, bool include_jvmti_agent_threads, bool include_jni_attaching_threads);
 public:
   ThreadsListEnumerator(Thread* cur_thread,
                         bool include_jvmti_agent_threads = false,


### PR DESCRIPTION
Summary: Now we can use ThreadMxBean to inspect coroutine infomation.

Test Plan: Support ThreadMxBean to inspect coroutine infomation,
including getThreadInfo, dumpAllThreads,getThreadCount, getAllThreadIds.

Reviewed-by: zhengxiaolinX, yuleil, sanhongli

Issue: https://github.com/alibaba/dragonwell8/issues/132