### PR TITLE
[JFR] Fixed missing Threads_lock protection when traversing thread list

### DIFF
--- a/src/share/vm/jfr/periodic/jfrPeriodic.cpp
+++ b/src/share/vm/jfr/periodic/jfrPeriodic.cpp
@@ -395,12 +395,17 @@ TRACE_REQUEST_FUNC(ThreadAllocationStatistics) {
   GrowableArray<jlong> allocated(initial_size);
   GrowableArray<traceid> thread_ids(initial_size);
   JfrTicks time_stamp = JfrTicks::now();
-  JfrJavaThreadIterator iter;
-  while (iter.has_next()) {
-    JavaThread* const jt = iter.next();
-    assert(jt != NULL, "invariant");
-    allocated.append(jt->cooked_allocated_bytes());
-    thread_ids.append(JFR_THREAD_ID(jt));
+
+  {
+    // Collect allocation statistics while holding threads lock
+    MutexLockerEx ml(Threads_lock);
+    JfrJavaThreadIterator iter;
+    while (iter.has_next()) {
+      JavaThread* const jt = iter.next();
+      assert(jt != NULL, "invariant");
+      allocated.append(jt->cooked_allocated_bytes());
+      thread_ids.append(JFR_THREAD_ID(jt));
+    }
   }
 
   // Write allocation statistics to buffer.

--- a/src/share/vm/jfr/recorder/checkpoint/types/jfrType.cpp
+++ b/src/share/vm/jfr/recorder/checkpoint/types/jfrType.cpp
@@ -108,6 +108,7 @@ void JfrCheckpointThreadClosure::do_thread(Thread* t) {
 
 void JfrThreadConstantSet::serialize(JfrCheckpointWriter& writer) {
   JfrCheckpointThreadClosure tc(writer);
+  MutexLockerEx ml(Threads_lock);
   JfrJavaThreadIterator javathreads;
   while (javathreads.has_next()) {
     tc.do_thread(javathreads.next());


### PR DESCRIPTION
Summary:
TRACE_REQUEST_FUNC(ThreadAllocationStatistics) in jfrPeriodic.cpp
void JfrCheckpointThreadClosure::do_thread(Thread* t) in jfrType.cpp

Test Plan: jdk/test/jdk/jfr

Reviewed-by: kelthuzadx, zhengxiaolinX

Issue: https://github.com/alibaba/dragonwell8/issues/134