### PR TITLE
[GC] Elastic Heap should clear bitmap when committing region memory

### DIFF
--- a/src/share/vm/gc_implementation/g1/g1RegionToSpaceMapper.hpp
+++ b/src/share/vm/gc_implementation/g1/g1RegionToSpaceMapper.hpp
@@ -41,6 +41,7 @@ class G1MappingChangedListener VALUE_OBJ_CLASS_SPEC {
 // Maps region based commit/uncommit requests to the underlying page sized virtual
 // space.
 class G1RegionToSpaceMapper : public CHeapObj<mtGC> {
+ friend class HeapRegionManager;
  private:
   G1MappingChangedListener* _listener;
  protected:

--- a/src/share/vm/gc_implementation/g1/heapRegionManager.cpp
+++ b/src/share/vm/gc_implementation/g1/heapRegionManager.cpp
@@ -113,6 +113,11 @@ void HeapRegionManager::commit_region_memory(uint idx) {
   }
 
   _heap_mapper->par_commit_region_memory(idx);
+
+  // Only the bitmap needs on-commit operations for free regions
+  // It's safe to clear bitmap range of a region parallelly
+  _prev_bitmap_mapper->fire_on_commit(idx, 1, false);
+  _next_bitmap_mapper->fire_on_commit(idx, 1, false);
 }
 
 void HeapRegionManager::free_region_memory(uint idx) {


### PR DESCRIPTION
Summary: Elastic Heap should clear bitmap when committing region memory

Reviewed-by: Hao Tang, Yude Lin

Test Plan: jtreg tests

https://github.com/alibaba/dragonwell8/issues/57