### PR TITLE
[GC] Backport 8204524: Unnecessary memory barriers in G1ParScanThread…

### DIFF
--- a/src/share/vm/gc_implementation/g1/g1CollectedHeap.cpp
+++ b/src/share/vm/gc_implementation/g1/g1CollectedHeap.cpp
@@ -4544,7 +4544,7 @@ G1CollectedHeap::handle_evacuation_failure_par(G1ParScanThreadState* _par_scan_s
          err_msg("obj: " PTR_FORMAT " should still be in the CSet",
                  (HeapWord*) old));
   markOop m = old->mark();
-  oop forward_ptr = old->forward_to_atomic(old);
+  oop forward_ptr = old->forward_to_atomic(old, memory_order_relaxed);
   if (forward_ptr == NULL) {
     // Forward-to-self succeeded.
     assert(_par_scan_state != NULL, "par scan state");

--- a/src/share/vm/gc_implementation/g1/g1ParScanThreadState.cpp
+++ b/src/share/vm/gc_implementation/g1/g1ParScanThreadState.cpp
@@ -261,7 +261,7 @@ oop G1ParScanThreadState::copy_to_survivor_space(InCSetState const state,
   Prefetch::write(obj_ptr, PrefetchCopyIntervalInBytes);
 
   const oop obj = oop(obj_ptr);
-  const oop forward_ptr = old->forward_to_atomic(obj);
+  const oop forward_ptr = old->forward_to_atomic(obj, memory_order_relaxed);
   if (forward_ptr == NULL) {
     Copy::aligned_disjoint_words((HeapWord*) old, obj_ptr, word_sz);
 

--- a/src/share/vm/gc_implementation/parNew/parNewGeneration.cpp
+++ b/src/share/vm/gc_implementation/parNew/parNewGeneration.cpp
@@ -1209,7 +1209,7 @@ oop ParNewGeneration::copy_to_survivor_space_avoiding_promotion_undo(
 
     // Attempt to install a null forwarding pointer (atomically),
     // to claim the right to install the real forwarding pointer.
-    forward_ptr = old->forward_to_atomic(ClaimedForwardPtr);
+    forward_ptr = old->forward_to_atomic(ClaimedForwardPtr, memory_order_relaxed);
     if (forward_ptr != NULL) {
       // someone else beat us to it.
         return real_forwardee(old);
@@ -1234,7 +1234,7 @@ oop ParNewGeneration::copy_to_survivor_space_avoiding_promotion_undo(
   } else {
     // Is in to-space; do copying ourselves.
     Copy::aligned_disjoint_words((HeapWord*)old, (HeapWord*)new_obj, sz);
-    forward_ptr = old->forward_to_atomic(new_obj);
+    forward_ptr = old->forward_to_atomic(new_obj, memory_order_relaxed);
     // Restore the mark word copied above.
     new_obj->set_mark(m);
     // Increment age if obj still in new generation
@@ -1340,7 +1340,7 @@ oop ParNewGeneration::copy_to_survivor_space_with_undo(
 
     if (new_obj == NULL) {
       // promotion failed, forward to self
-      forward_ptr = old->forward_to_atomic(old);
+      forward_ptr = old->forward_to_atomic(old, memory_order_relaxed);
       new_obj = old;
 
       if (forward_ptr != NULL) {
@@ -1378,7 +1378,7 @@ oop ParNewGeneration::copy_to_survivor_space_with_undo(
   // We have to copy the mark word before overwriting with forwarding
   // ptr, so we can restore it below in the copy.
   if (!failed_to_promote) {
-    forward_ptr = old->forward_to_atomic(new_obj);
+    forward_ptr = old->forward_to_atomic(new_obj, memory_order_relaxed);
   }
 
   if (forward_ptr == NULL) {

--- a/src/share/vm/oops/oop.hpp
+++ b/src/share/vm/oops/oop.hpp
@@ -339,7 +339,7 @@ class oopDesc {
   // Exactly one thread succeeds in inserting the forwarding pointer, and
   // this call returns "NULL" for that thread; any other thread has the
   // value of the forwarding pointer returned and does not modify "this".
-  oop forward_to_atomic(oop p);
+  oop forward_to_atomic(oop p, cmpxchg_memory_order order);
 #endif // INCLUDE_ALL_GCS
 
   oop forwardee() const;

--- a/src/share/vm/oops/oop.pcgc.inline.hpp
+++ b/src/share/vm/oops/oop.pcgc.inline.hpp
@@ -54,7 +54,7 @@ inline void oopDesc::follow_contents(ParCompactionManager* cm) {
   klass()->oop_follow_contents(cm, this);
 }
 
-inline oop oopDesc::forward_to_atomic(oop p) {
+inline oop oopDesc::forward_to_atomic(oop p, cmpxchg_memory_order order) {
   assert(ParNewGeneration::is_legal_forward_ptr(p),
          "illegal forwarding pointer value.");
   markOop oldMark = mark();
@@ -65,7 +65,7 @@ inline oop oopDesc::forward_to_atomic(oop p) {
   assert(sizeof(markOop) == sizeof(intptr_t), "CAS below requires this.");
 
   while (!oldMark->is_marked()) {
-    curMark = (markOop)Atomic::cmpxchg_ptr(forwardPtrMark, &_mark, oldMark);
+    curMark = (markOop)Atomic::cmpxchg_ptr(forwardPtrMark, &_mark, oldMark, memory_order_relaxed);
     assert(is_forwarded(), "object should have been forwarded");
     if (curMark == oldMark) {
       return NULL;


### PR DESCRIPTION
Summary: full fences before/after the CAS for an object copy is not necessary
  - Covered ParNew as well. JDK-8205908 supposed to do this but not implemented.

Test Plan: hotspot/test/gc/{g1,parNew}/

Reviewed-by: linade, mmyxym

Issue: https://github.com/alibaba/dragonwell8/issues/154