### PR TITLE
[GC] Backport 8164948: Initializing stores of HeapRegions are not ord…

### DIFF
--- a/src/share/vm/gc_implementation/g1/concurrentMark.cpp
+++ b/src/share/vm/gc_implementation/g1/concurrentMark.cpp
@@ -3006,6 +3006,9 @@ ConcurrentMark::claim_region(uint worker_id) {
     // iterations) but it should not introduce and correctness issues.
     HeapRegion* curr_region = _g1h->heap_region_containing_raw(finger);
 
+    // Make sure that the reads below do not float before loading curr_region.
+    OrderAccess::loadload();
+
     // Above heap_region_containing_raw may return NULL as we always scan claim
     // until the end of the heap. In this case, just jump to the next region.
     HeapWord* end = curr_region != NULL ? curr_region->end() : finger + HeapRegion::GrainWords;

--- a/src/share/vm/gc_implementation/g1/heapRegionManager.cpp
+++ b/src/share/vm/gc_implementation/g1/heapRegionManager.cpp
@@ -158,6 +158,7 @@ void HeapRegionManager::make_regions_available(uint start, uint num_regions) {
   for (uint i = start; i < start + num_regions; i++) {
     if (_regions.get_by_index(i) == NULL) {
       HeapRegion* new_hr = new_heap_region(i);
+      OrderAccess::storestore();
       _regions.set_by_index(i, new_hr);
       _allocated_heapregions_length = MAX2(_allocated_heapregions_length, i + 1);
     }


### PR DESCRIPTION
Summary: Add a `storestore` barrier before publishing newly initialized
HeapRegion instances, and place a `loadload` barrier before use of
members. (http://hg.openjdk.java.net/jdk9/jdk9/hotspot/rev/cd2c49a02a4c)

Test Plan: hotspot/test/gc/g1

Reviewed-by: linade, mmyxym

Issue: https://github.com/alibaba/dragonwell8/issues/155