### PR TITLE
[Wisp] Disable any platform but x86_64 for Wisp

### DIFF
--- a/src/share/vm/runtime/arguments.cpp
+++ b/src/share/vm/runtime/arguments.cpp
@@ -4140,11 +4140,9 @@ jint Arguments::parse(const JavaVMInitArgs* args) {
     }
   }
 
-#ifndef LINUX
+#if !(defined(LINUX) && defined(AMD64))
   if (EnableCoroutine || UseWispMonitor) {
-    warning("Wisp supports Linux only"
-            "; ignore Wisp related flags");
-    EnableCoroutine = UseWispMonitor = false;
+    vm_exit_during_initialization("Wisp only works on Linux x64 platform for now");
   }
 #endif
 


### PR DESCRIPTION
Summary: Wisp has platform-related code, which requires Wisp to be disabled in any other platform.

Test Plan: -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 on AArch64 platform, also other sanity tests

Reviewed-by: leiyul, ziyilin

Issue: alibaba/dragonwell8#157