### PR TITLE
[Wisp] Support AArch64 platform

### DIFF
--- a/src/cpu/aarch64/vm/aarch64.ad
+++ b/src/cpu/aarch64/vm/aarch64.ad
@@ -3355,6 +3355,11 @@ encode %{
       __ add(tmp, disp_hdr, (ObjectMonitor::owner_offset_in_bytes()-markOopDesc::monitor_value));
       __ mov(disp_hdr, zr);
 
+      if (UseWispMonitor) {
+        __ ldr (rthread, Address(rthread, JavaThread::current_coroutine_offset()));
+        __ ldr (rthread, Address(rthread, Coroutine::wisp_thread_offset()));
+      }
+
       if (UseLSE) {
         __ mov(rscratch1, disp_hdr);
         __ casal(Assembler::xword, rscratch1, rthread, tmp);
@@ -3371,6 +3376,10 @@ encode %{
 	__ stlxr(rscratch1, rthread, tmp);
 	__ cbnzw(rscratch1, retry_load);
 	__ bind(fail);
+      }
+
+      if (UseWispMonitor) {
+        __ ldr (rthread, Address(rthread, WispThread::thread_offset()));
       }
 
       // Store a non-null value into the box to avoid looking like a re-entrant
@@ -3451,7 +3460,14 @@ encode %{
       __ add(tmp, tmp, -markOopDesc::monitor_value); // monitor
       __ ldr(rscratch1, Address(tmp, ObjectMonitor::owner_offset_in_bytes()));
       __ ldr(disp_hdr, Address(tmp, ObjectMonitor::recursions_offset_in_bytes()));
+      if (UseWispMonitor) {
+        __ ldr (rthread, Address(rthread, JavaThread::current_coroutine_offset()));
+        __ ldr (rthread, Address(rthread, Coroutine::wisp_thread_offset()));
+      }
       __ eor(rscratch1, rscratch1, rthread); // Will be 0 if we are the owner.
+      if (UseWispMonitor) {
+        __ ldr (rthread, Address(rthread, WispThread::thread_offset()));
+      }
       __ orr(rscratch1, rscratch1, disp_hdr); // Will be 0 if there are 0 recursions
       __ cmp(rscratch1, zr);
       __ br(Assembler::NE, cont);
@@ -13795,6 +13811,25 @@ instruct tlsLoadP(thread_RegP dst)
 
   ins_pipe(pipe_class_empty);
 %}
+
+// Thread refetch:
+// take two main arguments:
+// 1. register @rthread
+// 2. one register which contains the `Coroutine *`
+// and move Coroutine->_thread to @rthread
+instruct tlsRefetchP(thread_RegP dst, iRegP src)
+%{
+  match(Set dst (ThreadRefetch src));
+
+  format %{ "Refetch the rthread register" %}
+
+  ins_encode %{
+  __ ldr(rthread, Address($src$$Register, Coroutine::thread_offset()));
+  %}
+
+  ins_pipe(pipe_class_empty);
+%}
+
 
 // ====================VECTOR INSTRUCTIONS=====================================
 

--- a/src/cpu/aarch64/vm/c1_CodeStubs_aarch64.cpp
+++ b/src/cpu/aarch64/vm/c1_CodeStubs_aarch64.cpp
@@ -297,8 +297,31 @@ void MonitorExitStub::emit_code(LIR_Assembler* ce) {
   } else {
     exit_id = Runtime1::monitorexit_nofpu_id;
   }
+  // Handle special case for wisp unpark.
+  // The code stub is entered only when the following four conditions are all satisfied
+  // 1. A synchronized method is compiled by C1
+  // 2. An exception happened in this method
+  // 3. There is no exception handler in this method, So it needs to unwind to its caller
+  // 4. GC happened during unpark
+  // if (_info == NULL) is true, the four conditions are all true.
+  if (UseWispMonitor && (_info == NULL)) {
+    if (exit_id == Runtime1::monitorexit_id) {
+      exit_id = Runtime1::monitorexit_proxy_id;
+    } else {
+      assert (exit_id == Runtime1::monitorexit_nofpu_id, "must be monitorexit_nofpu_id");
+      exit_id = Runtime1::monitorexit_nofpu_proxy_id;
+    }
+  }
+  // on X86, despite we will call java, we have no need to generate an oopmap here,
+  // because c1_CodeStubs_x86.cpp only emit a jump here, when GC happens, we won't
+  // see the _last_pc pointing here.
+  // However, on aarch64 here it uses lr to jump from the far_jump stub.
+  // so the _last_pc will be seen by stack unwinding as a single frame,
+  // when GC searches the pc related oopmap, it will crash.
+  // so, because of this implementation we should emit the OopMap where the `continuation` lays.
   __ adr(lr, _continuation);
   __ far_jump(RuntimeAddress(Runtime1::entry_for(exit_id)));
+  __ should_not_reach_here();
 }
 
 

--- a/src/cpu/aarch64/vm/c1_LIRAssembler_aarch64.cpp
+++ b/src/cpu/aarch64/vm/c1_LIRAssembler_aarch64.cpp
@@ -423,7 +423,7 @@ int LIR_Assembler::emit_unwind_handler() {
   MonitorExitStub* stub = NULL;
   if (method()->is_synchronized()) {
     monitor_address(0, FrameMap::r0_opr);
-    stub = new MonitorExitStub(FrameMap::r0_opr, true, 0);
+    stub = new MonitorExitStub(FrameMap::r0_opr, true, 0, NULL);
     __ unlock_object(r5, r4, r0, *stub->entry());
     __ bind(*stub->continuation());
   }
@@ -2592,6 +2592,13 @@ void LIR_Assembler::emit_lock(LIR_OpLock* op) {
     Unimplemented();
   }
   __ bind(*op->stub()->continuation());
+  // add an OopMap here.
+  if (UseWispMonitor && op->code() == lir_unlock) {
+    // For direct unpark in Wisp, _info must be recorded to generate the oopmap.
+    guarantee(op->info() != NULL, "aarch64 needs an OopMap because the adr(lr, ...), so pc will be searched for the OopMap");
+    add_call_info_here(op->info());
+    verify_oop_map(op->info());
+  }
 }
 
 

--- a/src/cpu/aarch64/vm/c1_LIRGenerator_aarch64.cpp
+++ b/src/cpu/aarch64/vm/c1_LIRGenerator_aarch64.cpp
@@ -432,7 +432,18 @@ void LIRGenerator::do_MonitorExit(MonitorExit* x) {
   LIR_Opr lock = new_register(T_INT);
   LIR_Opr obj_temp = new_register(T_INT);
   set_no_result(x);
-  monitor_exit(obj_temp, lock, syncTempOpr(), LIR_OprFact::illegalOpr, x->monitor_no());
+  // Info is used to generate the oopmap, which is necessary for calling java code during runtime.
+  if (UseWispMonitor) {
+    CodeEmitInfo *info = NULL;
+    if (x->state()) {
+      info = state_for(x, x->state(), true);
+    }
+    // add info_for_exception CodeInfo here.
+    CodeEmitInfo *info_for_exception = state_for(x, x->state(), true);
+    monitor_exit(obj_temp, lock, syncTempOpr(), LIR_OprFact::illegalOpr, x->monitor_no(), info_for_exception, info);
+  } else {
+    monitor_exit(obj_temp, lock, syncTempOpr(), LIR_OprFact::illegalOpr, x->monitor_no());
+  }
 }
 
 

--- a/src/cpu/aarch64/vm/c1_Runtime1_aarch64.cpp
+++ b/src/cpu/aarch64/vm/c1_Runtime1_aarch64.cpp
@@ -46,6 +46,8 @@
 #include "gc_implementation/g1/g1SATBCardTableModRefBS.hpp"
 #endif
 
+// the Runtime1::monitorenter function pointer
+extern address monitorenter_address_C1;
 
 // Implementation of StubAssembler
 
@@ -67,6 +69,18 @@ int StubAssembler::call_RT(Register oop_result1, Register metadata_result, addre
   blr(rscratch1);
   bind(retaddr);
   int call_offset = offset();
+
+  // the call_offset is the pc for the call()'s return rip so that it should be
+  // inserted directly after the call.
+  // the call_offset is used for something like 'frame::sender_for_compiled_frame'
+  // in order to use the call_offset as the pc address to find the OopMap address
+  if (EnableCoroutine) {
+    // only if the entry_point is equal to `Runtime1::monitorenter()` will we do this amendment.
+    if (entry == monitorenter_address_C1) {
+      WISP_V2v_UPDATE;
+    }
+  }
+
   // verify callee-saved register
 #ifdef ASSERT
   push(r0, sp);
@@ -1058,6 +1072,11 @@ OopMapSet* Runtime1::generate_code_for(StubID id, StubAssembler* sasm) {
         oop_maps = new OopMapSet();
         oop_maps->add_gc_map(call_offset, map);
         restore_live_registers(sasm, save_fpu_registers);
+
+        if (EnableCoroutine) {
+          // rthread has been forcibly restored in restore_live_registers so we need fix to it.
+          WISP_COMPILER_RESTORE_FORCE_UPDATE;
+        }
       }
       break;
 
@@ -1076,7 +1095,34 @@ OopMapSet* Runtime1::generate_code_for(StubID id, StubAssembler* sasm) {
         // note: really a leaf routine but must setup last java sp
         //       => use call_RT for now (speed can be improved by
         //       doing last java sp setup manually)
-        int call_offset = __ call_RT(noreg, noreg, CAST_FROM_FN_PTR(address, monitorexit), r0);
+        int call_offset = 0;
+        if (UseWispMonitor) {
+          call_offset  = __ call_RT(noreg, noreg, CAST_FROM_FN_PTR(address, monitorexit_wisp), r0);
+        } else {
+          call_offset  = __ call_RT(noreg, noreg, CAST_FROM_FN_PTR(address, monitorexit), r0);
+        }
+        oop_maps = new OopMapSet();
+        oop_maps->add_gc_map(call_offset, map);
+        restore_live_registers(sasm, save_fpu_registers);
+      }
+      break;
+    case monitorexit_nofpu_proxy_id:
+      save_fpu_registers = false;
+      // fall through
+    case monitorexit_proxy_id:
+      {
+        StubFrame f(sasm, "monitorexit", dont_gc_arguments);
+        OopMap* map = save_live_registers(sasm, save_fpu_registers);
+
+        // Called with store_parameter and not C abi
+        f.load_argument(0, r0); // r0,: lock address
+        int call_offset = 0;
+        if (UseWispMonitor) {
+          call_offset  = __ call_RT(noreg, noreg, CAST_FROM_FN_PTR(address, monitorexit_wisp_proxy), r0);
+        } else {
+          call_offset = 0;
+          __ should_not_reach_here();
+        }
 
         oop_maps = new OopMapSet();
         oop_maps->add_gc_map(call_offset, map);

--- a/src/cpu/aarch64/vm/coroutine_aarch64.cpp
+++ b/src/cpu/aarch64/vm/coroutine_aarch64.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2020 Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation. Alibaba designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "prims/privilegedStack.hpp"
+#include "runtime/coroutine.hpp"
+#include "runtime/globals.hpp"
+#include "runtime/objectMonitor.hpp"
+#include "runtime/objectMonitor.inline.hpp"
+#include "services/threadService.hpp"
+
+#include "coroutine_aarch64.hpp"
+#include "vmreg_aarch64.hpp"
+
+void Coroutine::set_coroutine_base(intptr_t **&base, JavaThread* thread, jobject obj, Coroutine *coro, oop coroutineObj, address coroutine_start) {
+  *(--base) = (intptr_t*)obj;
+  *(--base) = (intptr_t*)coro;
+  *(--base) = NULL;
+  *(--base) = (intptr_t*)coroutine_start;
+  *(--base) = NULL;
+  // we need one more pointer space compared to x86:
+  // see `create_switchTo_contents()`, which will push both `lr` and `rfp` onto the stack.
+  // rfp will be saved to this space, which will be the end of gc backtrace.
+  *(--base) = NULL;
+}
+
+Register CoroutineStack::get_fp_reg() {
+  return rfp;
+}

--- a/src/cpu/aarch64/vm/coroutine_aarch64.hpp
+++ b/src/cpu/aarch64/vm/coroutine_aarch64.hpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2020 Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation. Alibaba designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef CPU_AARCH64_VM_COROUTINE_AARCH64_HPP
+#define CPU_AARCH64_VM_COROUTINE_AARCH64_HPP
+
+#define R_TH rthread
+// the below `thread` lays on the stack: something like
+// `const Address thread(rfp, thread_off * wordSize);`
+#define WISP_j2v_UPDATE __ str(R_TH, thread)
+
+#endif // CPU_AARCH64_VM_COROUTINE_AARCH64_HPP

--- a/src/cpu/aarch64/vm/interp_masm_aarch64.cpp
+++ b/src/cpu/aarch64/vm/interp_masm_aarch64.cpp
@@ -404,6 +404,7 @@ void InterpreterMacroAssembler::jump_from_interpreted(Register method, Register 
 
   if (JvmtiExport::can_post_interpreter_events()) {
     Label run_compiled_code;
+    Label coroutine_skip_interpret;
     // JVMTI events, such as single-stepping, are implemented partly by avoiding running
     // compiled code in threads for which the event is enabled.  Check here for
     // interp_only_mode if these events CAN be enabled.
@@ -411,9 +412,23 @@ void InterpreterMacroAssembler::jump_from_interpreted(Register method, Register 
     // Is a cmpl faster?
     ldr(rscratch1, Address(rthread, JavaThread::interp_only_mode_offset()));
     cbz(rscratch1, run_compiled_code);
+    if (EnableCoroutine) {
+      // these code fixes for debugging java coroutine code (breakpoint)
+      // ldrb intruction will bzero the high 24 bits of the register
+      ldrb(rscratch1, Address(method, Method::intrinsic_id_offset_in_bytes()));
+      cmpw(rscratch1, vmIntrinsics::_switchTo);
+      br(Assembler::EQ, coroutine_skip_interpret);
+      cmpw(rscratch1, vmIntrinsics::_switchToAndExit);
+      br(Assembler::EQ, coroutine_skip_interpret);
+      cmpw(rscratch1, vmIntrinsics::_switchToAndTerminate);
+      br(Assembler::EQ, coroutine_skip_interpret);
+    }
     ldr(rscratch1, Address(method, Method::interpreter_entry_offset()));
     br(rscratch1);
     bind(run_compiled_code);
+    if (EnableCoroutine) {
+      bind(coroutine_skip_interpret);
+    }
   }
 
   ldr(rscratch1, Address(method, Method::from_interpreted_offset()));

--- a/src/cpu/aarch64/vm/macroAssembler_aarch64.cpp
+++ b/src/cpu/aarch64/vm/macroAssembler_aarch64.cpp
@@ -605,6 +605,8 @@ static void pass_arg3(MacroAssembler* masm, Register arg) {
   }
 }
 
+extern address monitorenter_address_interp;
+
 void MacroAssembler::call_VM_base(Register oop_result,
 				  Register java_thread,
 				  Register last_java_sp,
@@ -644,6 +646,13 @@ void MacroAssembler::call_VM_base(Register oop_result,
 
   // do the call, remove parameters
   MacroAssembler::call_VM_leaf_base(entry_point, number_of_arguments, &l);
+
+  if (EnableCoroutine) {
+    // only if the entry_point is equal to `Interpreter::monitorenter()` will we do this amendment.
+    if (entry_point == monitorenter_address_interp) {
+      WISP_V2v_UPDATE;
+    }
+  }
 
   // reset last Java frame
   // Only interpreter should have to clear fp
@@ -885,6 +894,16 @@ void MacroAssembler::get_vm_result(Register oop_result, Register java_thread) {
 void MacroAssembler::get_vm_result_2(Register metadata_result, Register java_thread) {
   ldr(metadata_result, Address(java_thread, JavaThread::vm_result_2_offset()));
   str(zr, Address(java_thread, JavaThread::vm_result_2_offset()));
+}
+
+void MacroAssembler::get_vm_result_for_wisp(Register oop_result, Register java_thread) {
+  assert(EnableCoroutine, "Coroutine is disabled");
+  ldr(oop_result, Address(java_thread, JavaThread::vm_result_for_wisp_offset()));
+  str(zr, Address(java_thread, JavaThread::vm_result_for_wisp_offset()));
+  // In default flow, after calling get_vm_result, vm_result is set to null.
+  // In wisp flow, we should also clear vm_result.
+  str(zr, Address(java_thread, JavaThread::vm_result_offset()));
+  verify_oop(oop_result, "broken oop in call_VM_base");
 }
 
 void MacroAssembler::align(int modulus) {

--- a/src/cpu/aarch64/vm/macroAssembler_aarch64.hpp
+++ b/src/cpu/aarch64/vm/macroAssembler_aarch64.hpp
@@ -711,6 +711,7 @@ public:
 
   void get_vm_result  (Register oop_result, Register thread);
   void get_vm_result_2(Register metadata_result, Register thread);
+  void get_vm_result_for_wisp(Register oop_result, Register thread);
 
   // These always tightly bind to MacroAssembler::call_VM_base
   // bypassing the virtual implementation

--- a/src/cpu/aarch64/vm/stubGenerator_aarch64.cpp
+++ b/src/cpu/aarch64/vm/stubGenerator_aarch64.cpp
@@ -324,6 +324,15 @@ class StubGenerator: public StubCodeGenerator {
     // pop parameters
     __ sub(esp, rfp, -sp_after_call_off * wordSize);
 
+    if (EnableCoroutine) {
+      Label L;    // the steal thread patch
+      __ ldr(rscratch1, thread);
+      __ cmp(rthread, rscratch1);
+      __ br(Assembler::EQ, L);
+      WISP_j2v_UPDATE;
+      __ bind(L);
+    }
+
 #ifdef ASSERT
     // verify that threads correspond
     {
@@ -398,6 +407,11 @@ class StubGenerator: public StubCodeGenerator {
     // same as in generate_call_stub():
     const Address sp_after_call(rfp, sp_after_call_off * wordSize);
     const Address thread        (rfp, thread_off         * wordSize);
+
+    if (EnableCoroutine) {
+      // to pass the assertion fail
+      WISP_j2v_UPDATE;
+    }
 
 #ifdef ASSERT
     // verify that threads correspond

--- a/src/share/vm/c1/c1_Runtime1.cpp
+++ b/src/share/vm/c1/c1_Runtime1.cpp
@@ -210,13 +210,8 @@ void Runtime1::generate_blob_for(BufferBlob* buffer_blob, StubID id) {
 
     // All other stubs should have oopmaps
     default:
-#ifdef X86
       assert(oop_maps != NULL, "must have an oopmap");
-#else
-      // TODO add support for monitorexit_nofpu_proxy_id
-      assert(oop_maps != NULL || (id == monitorexit_nofpu_proxy_id) || (id == monitorexit_proxy_id), "must have an oopmap");
       break;
-#endif
   }
 #endif
 

--- a/src/share/vm/runtime/arguments.cpp
+++ b/src/share/vm/runtime/arguments.cpp
@@ -4140,7 +4140,7 @@ jint Arguments::parse(const JavaVMInitArgs* args) {
     }
   }
 
-#if !(defined(LINUX) && defined(AMD64))
+#if !(defined(LINUX) && (defined(AMD64) || (defined(AARCH64))))
   if (EnableCoroutine || UseWispMonitor) {
     vm_exit_during_initialization("Wisp only works on Linux x64 platform for now");
   }

--- a/src/share/vm/runtime/coroutine.cpp
+++ b/src/share/vm/runtime/coroutine.cpp
@@ -38,6 +38,9 @@
 #ifdef TARGET_ARCH_zero
 # include "vmreg_zero.inline.hpp"
 #endif
+#ifdef TARGET_ARCH_aarch64
+# include "vmreg_aarch64.inline.hpp"
+#endif
 
 
 #ifdef _WINDOWS
@@ -143,12 +146,7 @@ Coroutine* Coroutine::create_coroutine(JavaThread* thread, CoroutineStack* stack
   jobject obj = JNIHandles::make_global(coroutineObj);
 
   intptr_t** d = (intptr_t**)stack->stack_base();
-#ifndef TARGET_ARCH_aarch64
   set_coroutine_base(d, thread, obj, coro, coroutineObj, (address)coroutine_start);
-#else
-  // FIXME
-  guarantee(false, "add coroutine_aarch64.hpp on aarch64 platform");
-#endif
 
   stack->set_last_sp((address) d);
 
@@ -467,12 +465,7 @@ void CoroutineStack::frames_do(FrameClosure* fc) {
   // see comments in `frame::sender()`
   // if the sender is a compiler frame, we cannot assume its value.
   StackFrameStream fst(_thread, fr);
-#ifndef TARGET_ARCH_aarch64
   fst.register_map()->set_location(get_fp_reg()->as_VMReg(), (address)_last_sp);
-#else
-  // FIXME
-  guarantee(false, "add coroutine_aarch64.hpp on aarch64 platform");
-#endif
   fst.register_map()->set_include_argument_oops(false);
   for(; !fst.is_done(); fst.next()) {
     fc->frames_do(fst.current(), fst.register_map());
@@ -485,12 +478,7 @@ frame CoroutineStack::last_frame(Coroutine* coro, RegisterMap& map) const {
   intptr_t* fp = ((intptr_t**)_last_sp)[0];
   address pc = ((address*)_last_sp)[1];
   intptr_t* sp = ((intptr_t*)_last_sp) + 2;
-#ifndef TARGET_ARCH_aarch64
   map.set_location(get_fp_reg()->as_VMReg(), (address)_last_sp);
-#else
-  // FIXME
-  guarantee(false, "add coroutine_aarch64.hpp on aarch64 platform");
-#endif
   map.set_include_argument_oops(false);
 
   frame f(sp, fp, pc);

--- a/src/share/vm/runtime/coroutine.hpp
+++ b/src/share/vm/runtime/coroutine.hpp
@@ -523,6 +523,9 @@ public:
 #ifdef TARGET_ARCH_x86
 # include "coroutine_x86.hpp"
 #endif
+#ifdef TARGET_ARCH_aarch64
+# include "coroutine_aarch64.hpp"
+#endif
 #define WISP_THREAD_UPDATE get_thread(R_TH)
 #define WISP_CALLING_CONVENTION_V2J_UPDATE __ WISP_THREAD_UPDATE
 #define WISP_CALLING_CONVENTION_V2j_UPDATE __ WISP_THREAD_UPDATE


### PR DESCRIPTION
Summary: Support AArch64 platform for Wisp
1. Port JKU coroutine switch logic
2. Port monitor exit support for Wisp monitor
3. Port platform related coroutine work steal support

Test Plan: all wisp tests on AArch64 platform

Reviewed-by: leiyul, kuaiwei

Issue: alibaba/dragonwell8#173