### PR TITLE
[Wisp] Fix deoptimization when monitorexit calls java in synchronized methods or blocks

### DIFF
--- a/src/cpu/aarch64/vm/c1_CodeStubs_aarch64.cpp
+++ b/src/cpu/aarch64/vm/c1_CodeStubs_aarch64.cpp
@@ -304,7 +304,7 @@ void MonitorExitStub::emit_code(LIR_Assembler* ce) {
   // 3. There is no exception handler in this method, So it needs to unwind to its caller
   // 4. GC happened during unpark
   // if (_info == NULL) is true, the four conditions are all true.
-  if (UseWispMonitor && (_info == NULL)) {
+  if (UseWispMonitor && (_info == NULL || _at_method_return)) {
     if (exit_id == Runtime1::monitorexit_id) {
       exit_id = Runtime1::monitorexit_proxy_id;
     } else {

--- a/src/cpu/aarch64/vm/c1_LIRAssembler_aarch64.cpp
+++ b/src/cpu/aarch64/vm/c1_LIRAssembler_aarch64.cpp
@@ -423,7 +423,7 @@ int LIR_Assembler::emit_unwind_handler() {
   MonitorExitStub* stub = NULL;
   if (method()->is_synchronized()) {
     monitor_address(0, FrameMap::r0_opr);
-    stub = new MonitorExitStub(FrameMap::r0_opr, true, 0, NULL);
+    stub = new MonitorExitStub(FrameMap::r0_opr, true, 0, NULL, true);
     __ unlock_object(r5, r4, r0, *stub->entry());
     __ bind(*stub->continuation());
   }
@@ -2593,7 +2593,7 @@ void LIR_Assembler::emit_lock(LIR_OpLock* op) {
   }
   __ bind(*op->stub()->continuation());
   // add an OopMap here.
-  if (UseWispMonitor && op->code() == lir_unlock) {
+  if (UseWispMonitor && op->code() == lir_unlock && !op->at_method_return()) {
     // For direct unpark in Wisp, _info must be recorded to generate the oopmap.
     guarantee(op->info() != NULL, "aarch64 needs an OopMap because the adr(lr, ...), so pc will be searched for the OopMap");
     add_call_info_here(op->info());

--- a/src/cpu/aarch64/vm/c1_LIRGenerator_aarch64.cpp
+++ b/src/cpu/aarch64/vm/c1_LIRGenerator_aarch64.cpp
@@ -440,7 +440,7 @@ void LIRGenerator::do_MonitorExit(MonitorExit* x) {
     }
     // add info_for_exception CodeInfo here.
     CodeEmitInfo *info_for_exception = state_for(x, x->state(), true);
-    monitor_exit(obj_temp, lock, syncTempOpr(), LIR_OprFact::illegalOpr, x->monitor_no(), info_for_exception, info);
+    monitor_exit(obj_temp, lock, syncTempOpr(), LIR_OprFact::illegalOpr, x->monitor_no(), info_for_exception, info, x->at_method_return());
   } else {
     monitor_exit(obj_temp, lock, syncTempOpr(), LIR_OprFact::illegalOpr, x->monitor_no());
   }

--- a/src/cpu/aarch64/vm/sharedRuntime_aarch64.cpp
+++ b/src/cpu/aarch64/vm/sharedRuntime_aarch64.cpp
@@ -2107,7 +2107,12 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     __ ldr(r19, Address(rthread, in_bytes(Thread::pending_exception_offset())));
     __ str(zr, Address(rthread, in_bytes(Thread::pending_exception_offset())));
 
-    rt_call(masm, CAST_FROM_FN_PTR(address, SharedRuntime::complete_monitor_unlocking_C), 2, 0, 1);
+    if (UseWispMonitor) {
+      __ mov(c_rarg2, rthread);
+      rt_call(masm, CAST_FROM_FN_PTR(address, SharedRuntime::complete_wisp_monitor_unlocking_C), 3, 0, 1);
+    } else {
+      rt_call(masm, CAST_FROM_FN_PTR(address, SharedRuntime::complete_monitor_unlocking_C), 2, 0, 1);
+    }
 
 #ifdef ASSERT
     {

--- a/src/cpu/x86/vm/c1_CodeStubs_x86.cpp
+++ b/src/cpu/x86/vm/c1_CodeStubs_x86.cpp
@@ -273,7 +273,7 @@ void MonitorExitStub::emit_code(LIR_Assembler* ce) {
   // 3. There is no exception handler in this method, So it needs to unwind to its caller
   // 4. GC happened during unpark
   // if (_info == NULL) is true, the four condistions are all true.
-  if (UseWispMonitor && (_info == NULL)) {
+  if (UseWispMonitor && (_info == NULL || _at_method_return)) {
     if (exit_id == Runtime1::monitorexit_id) {
       exit_id = Runtime1::monitorexit_proxy_id;
     } else {
@@ -283,7 +283,7 @@ void MonitorExitStub::emit_code(LIR_Assembler* ce) {
   }
   __ call(RuntimeAddress(Runtime1::entry_for(exit_id)));
   // For direct unpark in Wisp, _info must be recorded to generate oopmap.
-  if (UseWispMonitor && _info) {
+  if (UseWispMonitor && _info && !_at_method_return) {
     ce->add_call_info_here(_info);
     ce->verify_oop_map(_info);
   }

--- a/src/cpu/x86/vm/c1_LIRAssembler_x86.cpp
+++ b/src/cpu/x86/vm/c1_LIRAssembler_x86.cpp
@@ -449,7 +449,7 @@ int LIR_Assembler::emit_unwind_handler() {
   MonitorExitStub* stub = NULL;
   if (method()->is_synchronized()) {
     monitor_address(0, FrameMap::rax_opr);
-    stub = new MonitorExitStub(FrameMap::rax_opr, true, 0, NULL);
+    stub = new MonitorExitStub(FrameMap::rax_opr, true, 0, NULL, true);
     __ unlock_object(rdi, rsi, rax, *stub->entry());
     __ bind(*stub->continuation());
   }

--- a/src/cpu/x86/vm/c1_LIRGenerator_x86.cpp
+++ b/src/cpu/x86/vm/c1_LIRGenerator_x86.cpp
@@ -379,7 +379,7 @@ void LIRGenerator::do_MonitorExit(MonitorExit* x) {
     if (x->state()) {
       info = state_for(x, x->state(), true);
     }
-    monitor_exit(obj_temp, lock, syncTempOpr(), LIR_OprFact::illegalOpr, x->monitor_no(), NULL, info);
+    monitor_exit(obj_temp, lock, syncTempOpr(), LIR_OprFact::illegalOpr, x->monitor_no(), NULL, info, x->at_method_return());
   } else {
     monitor_exit(obj_temp, lock, syncTempOpr(), LIR_OprFact::illegalOpr, x->monitor_no());
   }

--- a/src/cpu/x86/vm/sharedRuntime_x86_64.cpp
+++ b/src/cpu/x86/vm/sharedRuntime_x86_64.cpp
@@ -2651,7 +2651,12 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     __ movptr(rbx, Address(r15_thread, in_bytes(Thread::pending_exception_offset())));
     __ movptr(Address(r15_thread, in_bytes(Thread::pending_exception_offset())), (int32_t)NULL_WORD);
 
-    __ call(RuntimeAddress(CAST_FROM_FN_PTR(address, SharedRuntime::complete_monitor_unlocking_C)));
+    if (UseWispMonitor) {
+      __ mov(c_rarg2, r15_thread);
+      __ call(RuntimeAddress(CAST_FROM_FN_PTR(address, SharedRuntime::complete_wisp_monitor_unlocking_C)));
+    } else {
+      __ call(RuntimeAddress(CAST_FROM_FN_PTR(address, SharedRuntime::complete_monitor_unlocking_C)));
+    }
     __ mov(rsp, r12); // restore sp
     __ reinit_heapbase();
 #ifdef ASSERT

--- a/src/share/vm/c1/c1_CodeStubs.hpp
+++ b/src/share/vm/c1/c1_CodeStubs.hpp
@@ -341,15 +341,16 @@ class MonitorExitStub: public MonitorAccessStub {
   bool _compute_lock;
   int  _monitor_ix;
   CodeEmitInfo* _info;
+  bool _at_method_return;
  public:
 
   MonitorExitStub(LIR_Opr lock_reg, bool compute_lock, int monitor_ix)
     : MonitorAccessStub(LIR_OprFact::illegalOpr, lock_reg),
-      _compute_lock(compute_lock), _monitor_ix(monitor_ix) { }
+      _compute_lock(compute_lock), _monitor_ix(monitor_ix), _at_method_return(false) { }
   // This constructor is used in Wisp only. Generating CodeEmitInfo for furter use.
-  MonitorExitStub(LIR_Opr lock_reg, bool compute_lock, int monitor_ix, CodeEmitInfo* info)
+  MonitorExitStub(LIR_Opr lock_reg, bool compute_lock, int monitor_ix, CodeEmitInfo* info, bool at_method_return)
     : MonitorAccessStub(LIR_OprFact::illegalOpr, lock_reg),
-      _compute_lock(compute_lock), _monitor_ix(monitor_ix) {
+      _compute_lock(compute_lock), _monitor_ix(monitor_ix), _at_method_return(at_method_return) {
       if (info) {
         assert(UseWispMonitor, "This path should be reached only when using WispMonitor");
         _info = new CodeEmitInfo(info);

--- a/src/share/vm/c1/c1_GraphBuilder.cpp
+++ b/src/share/vm/c1/c1_GraphBuilder.cpp
@@ -1570,7 +1570,7 @@ void GraphBuilder::method_return(Value x) {
     } else {
       receiver = append(new Constant(new ClassConstant(method()->holder())));
     }
-    append_split(new MonitorExit(receiver, state()->unlock(), NULL));
+    append_split(new MonitorExit(receiver, state()->unlock(), NULL, true));
   }
 
   if (need_mem_bar) {
@@ -2259,13 +2259,13 @@ void GraphBuilder::monitorexit(Value x, int bci, bool at_method_return) {
   if (UseWispMonitor) {
     if (at_method_return == false) {
       ValueStack* state_before = copy_state_for_exception_with_bci(bci);
-      Instruction* instr = new MonitorExit(x, state()->unlock(), state_before);
+      Instruction* instr = new MonitorExit(x, state()->unlock(), state_before, at_method_return);
       append_with_bci(instr, bci);
     } else {
-      append_with_bci(new MonitorExit(x, state()->unlock()), bci);
+      append_with_bci(new MonitorExit(x, state()->unlock(), NULL, at_method_return), bci);
     }
   } else {
-    append_with_bci(new MonitorExit(x, state()->unlock()), bci);
+    append_with_bci(new MonitorExit(x, state()->unlock(), NULL, at_method_return), bci);
   }
   kill_all();
 }

--- a/src/share/vm/c1/c1_Instruction.hpp
+++ b/src/share/vm/c1/c1_Instruction.hpp
@@ -1521,19 +1521,23 @@ LEAF(MonitorEnter, AccessMonitor)
 
 
 LEAF(MonitorExit, AccessMonitor)
+ private:
+  bool _at_method_return;
  public:
   // creation
   MonitorExit(Value obj, int monitor_no)
-  : AccessMonitor(obj, monitor_no, NULL)
+  : AccessMonitor(obj, monitor_no, NULL), _at_method_return(false)
   {
     ASSERT_VALUES
   }
 
-  MonitorExit(Value obj, int monitor_no, ValueStack* state_before)
-  : AccessMonitor(obj, monitor_no, state_before)
+  MonitorExit(Value obj, int monitor_no, ValueStack* state_before, bool at_method_return)
+  : AccessMonitor(obj, monitor_no, state_before), _at_method_return(at_method_return)
   {
     ASSERT_VALUES
   }
+ public:
+  bool at_method_return() const { return _at_method_return; }
 };
 
 

--- a/src/share/vm/c1/c1_LIR.cpp
+++ b/src/share/vm/c1/c1_LIR.cpp
@@ -1465,7 +1465,7 @@ void LIR_List::lock_object(LIR_Opr hdr, LIR_Opr obj, LIR_Opr lock, LIR_Opr scrat
                     info));
 }
 
-void LIR_List::unlock_object(LIR_Opr hdr, LIR_Opr obj, LIR_Opr lock, LIR_Opr scratch, CodeStub* stub, CodeEmitInfo* info) {
+void LIR_List::unlock_object(LIR_Opr hdr, LIR_Opr obj, LIR_Opr lock, LIR_Opr scratch, CodeStub* stub, CodeEmitInfo* info, bool at_method_return) {
   append(new LIR_OpLock(
                     lir_unlock,
                     hdr,
@@ -1473,7 +1473,8 @@ void LIR_List::unlock_object(LIR_Opr hdr, LIR_Opr obj, LIR_Opr lock, LIR_Opr scr
                     lock,
                     scratch,
                     stub,
-                    info));
+                    info,
+                    at_method_return));
 }
 
 

--- a/src/share/vm/c1/c1_LIR.hpp
+++ b/src/share/vm/c1/c1_LIR.hpp
@@ -1819,20 +1819,23 @@ class LIR_OpLock: public LIR_Op {
   LIR_Opr _lock;
   LIR_Opr _scratch;
   CodeStub* _stub;
+  bool _at_method_return;
  public:
-  LIR_OpLock(LIR_Code code, LIR_Opr hdr, LIR_Opr obj, LIR_Opr lock, LIR_Opr scratch, CodeStub* stub, CodeEmitInfo* info)
+  LIR_OpLock(LIR_Code code, LIR_Opr hdr, LIR_Opr obj, LIR_Opr lock, LIR_Opr scratch, CodeStub* stub, CodeEmitInfo* info, bool at_method_return = false)
     : LIR_Op(code, LIR_OprFact::illegalOpr, info)
     , _hdr(hdr)
     , _obj(obj)
     , _lock(lock)
     , _scratch(scratch)
-    , _stub(stub)                      {}
+    , _stub(stub)
+    , _at_method_return(at_method_return)  {}
 
   LIR_Opr hdr_opr() const                        { return _hdr; }
   LIR_Opr obj_opr() const                        { return _obj; }
   LIR_Opr lock_opr() const                       { return _lock; }
   LIR_Opr scratch_opr() const                    { return _scratch; }
   CodeStub* stub() const                         { return _stub; }
+  bool at_method_return() const                  { return _at_method_return; }
 
   virtual void emit_code(LIR_Assembler* masm);
   virtual LIR_OpLock* as_OpLock() { return this; }
@@ -2277,7 +2280,7 @@ class LIR_List: public CompilationResourceObj {
   }
 
   void load_stack_address_monitor(int monitor_ix, LIR_Opr dst)  { append(new LIR_Op1(lir_monaddr, LIR_OprFact::intConst(monitor_ix), dst)); }
-  void unlock_object(LIR_Opr hdr, LIR_Opr obj, LIR_Opr lock, LIR_Opr scratch, CodeStub* stub, CodeEmitInfo* info = NULL);
+  void unlock_object(LIR_Opr hdr, LIR_Opr obj, LIR_Opr lock, LIR_Opr scratch, CodeStub* stub, CodeEmitInfo* info = NULL, bool at_method_return = false);
   void lock_object(LIR_Opr hdr, LIR_Opr obj, LIR_Opr lock, LIR_Opr scratch, CodeStub* stub, CodeEmitInfo* info);
 
   void set_24bit_fpu()                                               { append(new LIR_Op0(lir_24bit_FPU )); }

--- a/src/share/vm/c1/c1_LIRGenerator.cpp
+++ b/src/share/vm/c1/c1_LIRGenerator.cpp
@@ -679,16 +679,16 @@ void LIRGenerator::monitor_enter(LIR_Opr object, LIR_Opr lock, LIR_Opr hdr, LIR_
 }
 
 
-void LIRGenerator::monitor_exit(LIR_Opr object, LIR_Opr lock, LIR_Opr new_hdr, LIR_Opr scratch, int monitor_no, CodeEmitInfo* info_for_exception, CodeEmitInfo* info) {
+void LIRGenerator::monitor_exit(LIR_Opr object, LIR_Opr lock, LIR_Opr new_hdr, LIR_Opr scratch, int monitor_no, CodeEmitInfo* info_for_exception, CodeEmitInfo* info, bool at_method_return) {
   if (!GenerateSynchronizationCode) return;
   // setup registers
   LIR_Opr hdr = lock;
   lock = new_hdr;
   CodeStub* slow_path;
   if (UseWispMonitor) {
-    slow_path = new MonitorExitStub(lock, UseFastLocking, monitor_no, info);
+    slow_path = new MonitorExitStub(lock, UseFastLocking, monitor_no, info, at_method_return);
     __ load_stack_address_monitor(monitor_no, lock);
-    __ unlock_object(hdr, object, lock, scratch, slow_path, info_for_exception);
+    __ unlock_object(hdr, object, lock, scratch, slow_path, info_for_exception, at_method_return);
   } else {
     slow_path = new MonitorExitStub(lock, UseFastLocking, monitor_no);
     __ load_stack_address_monitor(monitor_no, lock);

--- a/src/share/vm/c1/c1_LIRGenerator.hpp
+++ b/src/share/vm/c1/c1_LIRGenerator.hpp
@@ -333,7 +333,7 @@ class LIRGenerator: public InstructionVisitor, public BlockClosure {
   void logic_op   (Bytecodes::Code code, LIR_Opr dst_reg, LIR_Opr left, LIR_Opr right);
 
   void monitor_enter (LIR_Opr object, LIR_Opr lock, LIR_Opr hdr, LIR_Opr scratch, int monitor_no, CodeEmitInfo* info_for_exception, CodeEmitInfo* info);
-  void monitor_exit  (LIR_Opr object, LIR_Opr lock, LIR_Opr hdr, LIR_Opr scratch, int monitor_no, CodeEmitInfo* info_for_exception = NULL, CodeEmitInfo* info = NULL);
+  void monitor_exit  (LIR_Opr object, LIR_Opr lock, LIR_Opr hdr, LIR_Opr scratch, int monitor_no, CodeEmitInfo* info_for_exception = NULL, CodeEmitInfo* info = NULL, bool at_method_return = false);
 
   void new_instance    (LIR_Opr  dst, ciInstanceKlass* klass, bool is_unresolved, LIR_Opr  scratch1, LIR_Opr  scratch2, LIR_Opr  scratch3,  LIR_Opr scratch4, LIR_Opr  klass_reg, CodeEmitInfo* info);
 

--- a/src/share/vm/c1/c1_Runtime1.cpp
+++ b/src/share/vm/c1/c1_Runtime1.cpp
@@ -708,6 +708,7 @@ JRT_END
 // 4. GC happened during unpark
 // This path will not call Java, so JRT_LEAF is used.
 JRT_LEAF(void, Runtime1::monitorexit_wisp_proxy(JavaThread* thread, BasicObjectLock* lock))
+  No_Safepoint_Verifier nsv;
   NOT_PRODUCT(_monitorexit_slowcase_cnt++;)
   EXCEPTION_MARK;
   oop obj = lock->obj();
@@ -722,6 +723,9 @@ JRT_LEAF(void, Runtime1::monitorexit_wisp_proxy(JavaThread* thread, BasicObjectL
   } else {
     ObjectSynchronizer::fast_exit(obj, lock->lock(), THREAD);
   }
+  // proxy_unpark flag may get uncleared here. we need to force clear it
+  // to prevent disturbances from the monitorenter next time.
+  wisp_thread->clear_proxy_unpark_flag();
 JRT_END
 
 JRT_LEAF(void, Runtime1::monitorexit(JavaThread* thread, BasicObjectLock* lock))

--- a/src/share/vm/opto/callnode.hpp
+++ b/src/share/vm/opto/callnode.hpp
@@ -1074,13 +1074,15 @@ private:
 #ifdef ASSERT
   JVMState* const _dbg_jvms;      // Pointer to list of JVM State objects
 #endif
+  bool _at_method_return;
 public:
   virtual int Opcode() const;
   virtual uint size_of() const; // Size is bigger
-  UnlockNode(Compile* C, const TypeFunc *tf) : AbstractLockNode( tf )
+  UnlockNode(Compile* C, const TypeFunc *tf, bool at_method_return) : AbstractLockNode( tf )
 #ifdef ASSERT
     , _dbg_jvms(NULL)
 #endif
+    , _at_method_return(at_method_return)
   {
     init_class_id(Class_Unlock);
     init_flags(Flag_is_macro);
@@ -1097,6 +1099,7 @@ public:
 #else
   JVMState* dbg_jvms() const { return NULL; }
 #endif
+  bool at_method_return() const { return _at_method_return; }
 };
 
 #endif // SHARE_VM_OPTO_CALLNODE_HPP

--- a/src/share/vm/opto/graphKit.hpp
+++ b/src/share/vm/opto/graphKit.hpp
@@ -839,7 +839,7 @@ class GraphKit : public Phase {
   Node* insert_mem_bar_volatile(int opcode, int alias_idx, Node* precedent = NULL);
   // Optional 'precedent' is appended as an extra edge, to force ordering.
   FastLockNode* shared_lock(Node* obj);
-  void shared_unlock(Node* box, Node* obj);
+  void shared_unlock(Node* box, Node* obj, bool at_method_return = false);
 
   // helper functions for the fast path/slow path idioms
   Node* fast_and_slow(Node* in, const Type *result_type, Node* null_result, IfNode* fast_test, Node* fast_result, address slow_call, const TypeFunc *slow_call_type, Node* slow_arg, Klass* ex_klass, Node* slow_result);

--- a/src/share/vm/opto/macro.cpp
+++ b/src/share/vm/opto/macro.cpp
@@ -2536,9 +2536,12 @@ void PhaseMacroExpand::expand_unlock_node(UnlockNode *unlock) {
   Node *slow_path = opt_bits_test(ctrl, region, 2, funlock, 0, 0);
 
   CallNode *call;
-  if (UseWispMonitor &&
-      ((CallNode *)unlock->jvms() != NULL) && ((CallNode *)unlock->jvms()->has_method())) {
-    call = make_slow_call( (CallNode *) unlock, OptoRuntime::complete_monitor_exit_Type(), OptoRuntime::complete_wisp_monitor_unlocking_Java(), NULL, slow_path, obj, box );
+  if (UseWispMonitor) {
+    if (((CallNode *) unlock->jvms() != NULL) && ((CallNode *) unlock->jvms()->has_method()) && !unlock->at_method_return()) {
+      call = make_slow_call((CallNode *) unlock, OptoRuntime::complete_wisp_monitor_exit_Type(), OptoRuntime::complete_wisp_monitor_unlocking_Java(), NULL, slow_path, obj, box);
+    } else {
+      call = make_slow_call( (CallNode *) unlock, OptoRuntime::complete_monitor_exit_Type(), CAST_FROM_FN_PTR(address, SharedRuntime::complete_wisp_proxy_monitor_unlocking_C), "complete_wisp_proxy_monitor_unlocking_C", slow_path, obj, box);
+    }
   } else {
     call = make_slow_call( (CallNode *) unlock, OptoRuntime::complete_monitor_exit_Type(), CAST_FROM_FN_PTR(address, SharedRuntime::complete_monitor_unlocking_C), "complete_monitor_unlocking_C", slow_path, obj, box );
   }

--- a/src/share/vm/opto/parse1.cpp
+++ b/src/share/vm/opto/parse1.cpp
@@ -1042,7 +1042,7 @@ void Parse::do_exits() {
         // Add on the synchronized-method box/object combo
         kit.map()->push_monitor(_synch_lock);
         // Unlock!
-        kit.shared_unlock(_synch_lock->box_node(), _synch_lock->obj_node());
+        kit.shared_unlock(_synch_lock->box_node(), _synch_lock->obj_node(), true);
       }
       if (C->env()->dtrace_method_probes()) {
         kit.make_dtrace_method_exit(method());
@@ -2104,7 +2104,7 @@ void Parse::return_current(Node* value) {
   // Do not set_parse_bci, so that return goo is credited to the return insn.
   set_bci(InvocationEntryBci);
   if (method()->is_synchronized() && GenerateSynchronizationCode) {
-    shared_unlock(_synch_lock->box_node(), _synch_lock->obj_node());
+    shared_unlock(_synch_lock->box_node(), _synch_lock->obj_node(), true);
   }
   if (C->env()->dtrace_method_probes()) {
     make_dtrace_method_exit(method());

--- a/src/share/vm/opto/runtime.cpp
+++ b/src/share/vm/opto/runtime.cpp
@@ -177,7 +177,7 @@ bool OptoRuntime::generate(ciEnv* env) {
   gen(env, _g1_wb_pre_Java                 , g1_wb_pre_Type               , SharedRuntime::g1_wb_pre        ,    0 , false, false, false);
   gen(env, _g1_wb_post_Java                , g1_wb_post_Type              , SharedRuntime::g1_wb_post       ,    0 , false, false, false);
   gen(env, _complete_monitor_locking_Java  , complete_monitor_enter_Type  , SharedRuntime::complete_monitor_locking_C, 0, false, false, false);
-  gen(env, _complete_wisp_monitor_unlocking_Java  , complete_monitor_enter_Type  , SharedRuntime::complete_wisp_monitor_unlocking_C, 0, false, false, false);
+  gen(env, _complete_wisp_monitor_unlocking_Java  , complete_wisp_monitor_exit_Type  , SharedRuntime::complete_wisp_monitor_unlocking_C, 0, false, false, false);
   gen(env, _rethrow_Java                   , rethrow_Type                 , rethrow_C                       ,    2 , true , false, true );
 
   gen(env, _slow_arraycopy_Java            , slow_arraycopy_Type          , SharedRuntime::slow_arraycopy_C ,    0 , false, false, false);
@@ -649,6 +649,21 @@ const TypeFunc *OptoRuntime::complete_monitor_enter_Type() {
 
 //-----------------------------------------------------------------------------
 const TypeFunc *OptoRuntime::complete_monitor_exit_Type() {
+  // create input type (domain)
+  const Type **fields = TypeTuple::fields(2);
+  fields[TypeFunc::Parms+0] = TypeInstPtr::NOTNULL;  // Object to be Locked
+  fields[TypeFunc::Parms+1] = TypeRawPtr::BOTTOM;   // Address of stack location for lock
+  const TypeTuple *domain = TypeTuple::make(TypeFunc::Parms+2,fields);
+
+  // create result type (range)
+  fields = TypeTuple::fields(0);
+
+  const TypeTuple *range = TypeTuple::make(TypeFunc::Parms+0,fields);
+
+  return TypeFunc::make(domain,range);
+}
+
+const TypeFunc *OptoRuntime::complete_wisp_monitor_exit_Type() {
   // create input type (domain)
   const Type **fields = TypeTuple::fields(2);
   fields[TypeFunc::Parms+0] = TypeInstPtr::NOTNULL;  // Object to be Locked

--- a/src/share/vm/opto/runtime.hpp
+++ b/src/share/vm/opto/runtime.hpp
@@ -180,6 +180,7 @@ public:
   static void complete_monitor_locking_C(oopDesc* obj, BasicLock* lock, JavaThread* thread);
   static void complete_monitor_unlocking_C(oopDesc* obj, BasicLock* lock);
   static void complete_wisp_monitor_unlocking_C(oopDesc* obj, BasicLock* lock, JavaThread* thread);
+  static void complete_wisp_proxy_monitor_unlocking_C(oopDesc* obj, BasicLock* lock);
 
   // JFR support
   static void jfr_fast_object_alloc_C(oopDesc* obj, jint bci, JavaThread* thread);
@@ -282,6 +283,7 @@ private:
   static const TypeFunc* g1_wb_post_Type();
   static const TypeFunc* complete_monitor_enter_Type();
   static const TypeFunc* complete_monitor_exit_Type();
+  static const TypeFunc* complete_wisp_monitor_exit_Type();
   static const TypeFunc* uncommon_trap_Type();
   static const TypeFunc* athrow_Type();
   static const TypeFunc* rethrow_Type();

--- a/src/share/vm/runtime/sharedRuntime.hpp
+++ b/src/share/vm/runtime/sharedRuntime.hpp
@@ -498,6 +498,7 @@ class SharedRuntime: AllStatic {
   static void complete_monitor_locking_C(oopDesc* obj, BasicLock* lock, JavaThread* thread);
   static void complete_monitor_unlocking_C(oopDesc* obj, BasicLock* lock);
   static void complete_wisp_monitor_unlocking_C(oopDesc* obj, BasicLock* lock, JavaThread* thread);
+  static void complete_wisp_proxy_monitor_unlocking_C(oopDesc* obj, BasicLock* lock);
 
   // Resolving of calls
   static address resolve_static_call_C     (JavaThread *thread);

--- a/test/runtime/coroutine/deopt/MultiThreadWispRunner.java
+++ b/test/runtime/coroutine/deopt/MultiThreadWispRunner.java
@@ -1,0 +1,37 @@
+import com.alibaba.wisp.engine.WispEngine;
+import sun.misc.SharedSecrets;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+public class MultiThreadWispRunner {
+
+    public static void run(String name, int threadCount, int coroCount, int runCount, int outputCount, Runnable runnable) throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(threadCount * coroCount);
+        AtomicInteger id = new AtomicInteger();
+        ExecutorService es = Executors.newCachedThreadPool(r -> {
+            Thread t = new Thread(r);
+            t.setName(name + "_" + id.getAndIncrement());
+            return t;
+        });
+        IntStream.range(0, threadCount).forEach(ign -> es.execute(() -> {
+            AtomicInteger n = new AtomicInteger();
+            for (int i = 0; i < coroCount; i++) {
+                WispEngine.dispatch(() -> {
+                    while (n.get() < runCount) {
+                        runnable.run();
+                        if (n.incrementAndGet() % outputCount == 0) {
+                            System.out.println(SharedSecrets.getJavaLangAccess().currentThread0().getName() + "/" + n.get() / 1000 +"k");
+                        }
+                    }
+                    latch.countDown();
+                });
+            }
+        }));
+        latch.await();
+    }
+
+}

--- a/test/runtime/coroutine/deopt/TestMonitorExitDeopt.java
+++ b/test/runtime/coroutine/deopt/TestMonitorExitDeopt.java
@@ -1,0 +1,52 @@
+/*
+ * @test
+ * @summary Test deoptimization of _monitorexit bytecode for synchronized block
+ * @library /testlibrary /testlibrary/whitebox
+ * @build sun.hotspot.WhiteBox
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox sun.hotspot.WhiteBox$WhiteBoxPermission
+ * @run main/othervm -XX:TieredStopAtLevel=1 -XX:CompileCommand=compileonly,TestMonitorExitDeopt::wrapper -XX:+PrintDeoptimizationDetails -XX:+IgnoreUnrecognizedVMOptions -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 TestMonitorExitDeopt
+ * @run main/othervm -XX:-TieredCompilation -XX:CompileCommand=compileonly,TestMonitorExitDeopt::wrapper -XX:+PrintDeoptimizationDetails -XX:+IgnoreUnrecognizedVMOptions -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 TestMonitorExitDeopt
+ */
+
+import sun.hotspot.WhiteBox;
+
+public class TestMonitorExitDeopt {
+    private static WhiteBox WB = WhiteBox.getWhiteBox();
+
+    public static void main(String[] args) throws Exception {
+        new Thread(() -> {
+            for (int i = 0; i < 20; i++) {
+                try {
+                    Thread.sleep(500);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+                WB.deoptimizeAll();
+            }
+        }).start();
+        MultiThreadWispRunner.run(
+                "TestMonitorExitDeopt",
+                4,
+                4,
+                200_000,
+                100000,
+                () -> wrapper());
+    }
+
+    private volatile static byte WRITE_VAL = 1;
+
+    static final Object O_1 = new Object();
+    static final Object O_2 = new Object();
+    private static void wrapper() {
+        synchronized (O_1) {
+            synchronized (O_2) {
+                for (int i = 0; i < bs.length; i++) {
+                    bs[i] = WRITE_VAL;
+                }
+            }
+            // THIS WILL CAUSE A CRASH WHEN DEOPTIMIZING
+        }
+    }
+
+    static byte[] bs = new byte[12];
+}

--- a/test/runtime/coroutine/deopt/TestSynchronizedMethodDeopt.java
+++ b/test/runtime/coroutine/deopt/TestSynchronizedMethodDeopt.java
@@ -1,0 +1,87 @@
+/*
+ * @test
+ * @summary Test deoptimization of _return bytecode for synchronized method
+ * @library /testlibrary /testlibrary/whitebox
+ * @build sun.hotspot.WhiteBox
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox sun.hotspot.WhiteBox$WhiteBoxPermission
+ * @run main/othervm -XX:-TieredCompilation -XX:CompileCommand=compileonly,TestSynchronizedMethodDeopt::syncMethodWrite -XX:+PrintDeoptimizationDetails -XX:+IgnoreUnrecognizedVMOptions -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 TestSynchronizedMethodDeopt
+ * @run main/othervm -XX:TieredStopAtLevel=1 -XX:CompileCommand=compileonly,TestSynchronizedMethodDeopt::syncMethodWrite -XX:+PrintDeoptimizationDetails -XX:+IgnoreUnrecognizedVMOptions -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 TestSynchronizedMethodDeopt
+ */
+
+import sun.hotspot.WhiteBox;
+
+/**
+ * This test can reproduce two problems:
+ * 1. C1 deopt failed at _monitorexit during _return
+ * 2. C2 deopt fastdebug assertion fail:
+ *    assert(false) failed: Non-balanced monitor enter/exit! Likely JNI locking
+ *    It shows that _monitorenter executes once and _monitorexit executes twice
+ *    So C2 will throw an IllegalMonitorStateException in release mode.
+ */
+
+public class TestSynchronizedMethodDeopt {
+    private static WhiteBox WB = WhiteBox.getWhiteBox();
+
+    public static void main(String[] args) throws Exception {
+        new Thread(() -> {
+            for (int i = 0; i < 20; i++) {
+                try {
+                    Thread.sleep(500);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+                // we are deoptimizing frames including `syncMethodWrite` continuously,
+                // and do not mark the method not entrant.
+                WB.deoptimizeAll();
+            }
+        }).start();
+        MultiThreadWispRunner.run(
+                "TestSynchronizedMethodDeopt",
+                4,
+                4,
+                200_000,
+                100000,
+                () -> syncMethodWrite(3));
+    }
+
+    private volatile static byte WRITE_VAL = 1;
+
+    private static synchronized int syncMethodWrite(int p) {
+        // THIS METHOD'S _MONITOREXIT WILL CRASH
+
+        // In C2's code, we will set the SynchronizationEntryBCI to -1
+        // So if we deopt at monitorexit inside _return bytecode,
+        // the interpreter will restart the whole method from bci == 0.
+        // In C1's code, if a method isn't a inlined method, the bci has
+        // been set to the _return's bci instead of SynchronizationEntryBCI,
+        // so it's a UB and will crash.
+        // In theory I think C2 also has problem because the reexecution of the
+        // whole method but I have no evidence. so I add a bomb to prove it's true:
+
+        // =====================================================================
+        //                          THE SPECIAL BOMB
+        // =====================================================================
+        // The syncMethodWrite() will write things, and the `p` will be changed
+        // when entering into the method. If syncMethodWrite() get deopted and
+        // re-executed in C2, we will detect the value change of `p`.
+        // so we will step on this bomb and the test fails.
+        if (p == 100) {
+            System.err.println("SYNCHRONIZED METHOD RE-EXECUTES FROM BCI 0!");
+            // In coroutine this guy will be eaten by wisp. So it is telling you AN ERROR
+            // IS HAPPENING NOW only from code level.
+//            throw new Error("synchronized method deopted at monitorexit in _return, " +
+//                            "and the whole method reexecute from the bci == 0!");
+            System.exit(-100);
+        } else {
+            p = 100;
+        }
+
+        for (int i = 0; i < bs.length; i++) {
+            bs[i] = WRITE_VAL;
+        }
+
+        return p;
+    }
+
+    static byte[] bs = new byte[12];
+}

--- a/test/runtime/coroutine/deopt/TestSynchronizedMethodDeoptInDoExits.java
+++ b/test/runtime/coroutine/deopt/TestSynchronizedMethodDeoptInDoExits.java
@@ -1,0 +1,73 @@
+/*
+ * @test
+ * @summary Test UnlockNode in `Parse::do_exits()` for synchronized method
+ * @library /testlibrary /testlibrary/whitebox
+ * @build sun.hotspot.WhiteBox
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox sun.hotspot.WhiteBox$WhiteBoxPermission
+ * @run main/othervm -XX:-TieredCompilation -XX:CompileCommand=compileonly,TestSynchronizedMethodDeoptInDoExits::remove -XX:+PrintDeoptimizationDetails -XX:+IgnoreUnrecognizedVMOptions -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 TestSynchronizedMethodDeoptInDoExits
+ * @run main/othervm -XX:TieredStopAtLevel=1 -XX:CompileCommand=compileonly,TestSynchronizedMethodDeoptInDoExits::remove -XX:+PrintDeoptimizationDetails -XX:+IgnoreUnrecognizedVMOptions -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 TestSynchronizedMethodDeoptInDoExits
+ */
+
+
+import sun.hotspot.WhiteBox;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * This test won't have problem, only for Testing Parse::do_exits().
+ */
+
+public class TestSynchronizedMethodDeoptInDoExits {
+    private static WhiteBox WB = WhiteBox.getWhiteBox();
+
+    private static TestSynchronizedMethodDeoptInDoExits tsmdide = new TestSynchronizedMethodDeoptInDoExits();
+
+    public static void main(String[] args) throws Exception {
+        new Thread(() -> {
+            final long totalMillis = 20 * 500;
+            final long sleepMillis = 1;
+            for (int i = 0; i < totalMillis / sleepMillis; i++) {
+                try {
+                    Thread.sleep(sleepMillis);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+                // we are deoptimizing frames and do not mark the method not entrant.
+                WB.deoptimizeAll();
+            }
+        }).start();
+        MultiThreadWispRunner.run(
+                "TestSynchronizedMethodDeoptInDoExits",
+                4,
+                4,
+                100_000,
+                100000,
+                () -> trampoline());
+    }
+
+    private transient volatile ConcurrentHashMap<Object, Object> map = new ConcurrentHashMap<>();
+
+    // this method will go through Parse::do_exits()'s UnlockNode when the `key` is null
+    // we can use this guy for further testing
+    public synchronized int remove(Object key, int p) {
+        if (p == 100) {
+            System.err.println("SYNCHRONIZED METHOD RE-EXECUTES FROM BCI 0!");
+            System.exit(-100);
+        } else {
+            p = 100;
+        }
+        map.remove(key);
+        return p;
+    }
+
+    private static volatile Object NULL = null;
+
+    private static void trampoline() {
+        try {
+            tsmdide.remove(NULL, 3);
+        } catch (NullPointerException npe) {
+
+        }
+    }
+
+}

--- a/test/runtime/coroutine/deopt/TestSynchronizedMethodWhenUnwindingDeopt.java
+++ b/test/runtime/coroutine/deopt/TestSynchronizedMethodWhenUnwindingDeopt.java
@@ -1,0 +1,89 @@
+/*
+ * @test
+ * @summary Test deoptimization of _monitorexit bytecode for synchronized block
+ * @library /testlibrary /testlibrary/whitebox
+ * @build sun.hotspot.WhiteBox
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox sun.hotspot.WhiteBox$WhiteBoxPermission
+ * @run main/othervm -XX:TieredStopAtLevel=1 -XX:CompileCommand=compileonly,TestSynchronizedMethodWhenUnwindingDeopt::bar -XX:CompileCommand=compileonly,TestSynchronizedMethodWhenUnwindingDeopt::foo -XX:+PrintDeoptimizationDetails -XX:+IgnoreUnrecognizedVMOptions -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 TestSynchronizedMethodWhenUnwindingDeopt
+ * @run main/othervm -XX:-TieredCompilation -XX:CompileCommand=compileonly,TestSynchronizedMethodWhenUnwindingDeopt::bar -XX:CompileCommand=compileonly,TestSynchronizedMethodWhenUnwindingDeopt::foo -XX:+PrintDeoptimizationDetails -XX:+IgnoreUnrecognizedVMOptions -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 TestSynchronizedMethodWhenUnwindingDeopt
+ */
+
+import sun.hotspot.WhiteBox;
+
+// crash at: fatal error: Possible safepoint reached by thread that does not allow it
+/**
+ * V  [libjvm.so+0x1ea4de7]  VMError::report_and_die(int, char const*, char const*, __va_list_tag*, Thread*, unsigned char*, void*, void*, char const*, int, unsigned long)+0x187
+ * V  [libjvm.so+0x1ea5e77]  VMError::report_and_die(Thread*, void*, char const*, int, char const*, char const*, __va_list_tag*)+0x47
+ * V  [libjvm.so+0xfde22d]  report_fatal(char const*, int, char const*, ...)+0x10d
+ * V  [libjvm.so+0x1dc7cb7]  Thread::check_for_valid_safepoint_state(bool)+0xc7
+ * V  [libjvm.so+0x19f774f]  Monitor::check_prelock_state(Thread*, bool)+0xef
+ * V  [libjvm.so+0x19f79b8]  Monitor::lock(Thread*)+0x58
+ * V  [libjvm.so+0x1997186]  Method::build_interpreter_method_data(methodHandle const&, Thread*)+0x56
+ * V  [libjvm.so+0x13f5124]  InterpreterRuntime::profile_method(JavaThread*)+0x174
+ * j  java.lang.Class.cast(Ljava/lang/Object;)Ljava/lang/Object;+0
+ * j  java.lang.invoke.VarHandleObjects$FieldInstanceReadWrite.set(Ljava/lang/invoke/VarHandleObjects$FieldInstanceReadWrite;Ljava/lang/Object;Ljava/lang/Object;)V+23
+ * j  java.lang.invoke.VarHandleGuards.guard_LL_V(Ljava/lang/invoke/VarHandle;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/invoke/VarHandle$AccessDescriptor;)V+33
+ * j  java.util.concurrent.ConcurrentLinkedQueue$Node.<init>(Ljava/lang/Object;)V+9
+ * j  java.util.concurrent.ConcurrentLinkedQueue.offer(Ljava/lang/Object;)Z+8
+ * j  com.alibaba.wisp.engine.WispScheduler$Worker.pushAndSignal(Lcom/alibaba/wisp/engine/StealAwareRunnable;)Z+5
+ * j  com.alibaba.wisp.engine.WispScheduler$SchedulingPolicy$2.enqueue(Lcom/alibaba/wisp/engine/WispScheduler$Worker;ZLcom/alibaba/wisp/engine/StealAwareRunnable;)V+50
+ * j  com.alibaba.wisp.engine.WispScheduler.executeWithWorkerThread(Lcom/alibaba/wisp/engine/StealAwareRunnable;Ljava/lang/Thread;)V+46
+ * j  com.alibaba.wisp.engine.WispCarrier.wakeupTask(Lcom/alibaba/wisp/engine/WispTask;)V+83
+ * j  com.alibaba.wisp.engine.WispTask.unparkInternal(Z)V+55
+ * j  com.alibaba.wisp.engine.WispTask.unpark()V+2
+ * j  com.alibaba.wisp.engine.WispTask.unparkById(I)V+10
+ * v  ~StubRoutines::call_stub
+ * V  [libjvm.so+0x140d6f6]  JavaCalls::call_helper(JavaValue*, methodHandle const&, JavaCallArguments*, Thread*)+0x916
+ * V  [libjvm.so+0x1409a4e]  JavaCalls::call(JavaValue*, methodHandle const&, JavaCallArguments*, Thread*)+0x4e
+ * V  [libjvm.so+0xfcc379]  WispThread::unpark(int, bool, bool, ParkEvent*, WispThread*, Thread*)+0x389
+ * V  [libjvm.so+0x1a4e043]  ObjectMonitor::ExitEpilog(Thread*, ObjectWaiter*)+0xe3
+ * V  [libjvm.so+0x1d61813]  ObjectSynchronizer::fast_exit(Handle, BasicLock*, Thread*)+0x133
+ * V  [libjvm.so+0x1c5555f]  SharedRuntime::complete_monitor_unlocking_C(oopDesc*, BasicLock*, JavaThread*)+0x26f
+ * J 94 c2 TestSynchronizedMethodWhenUnwindingDeopt.foo()V (44 bytes) @ 0x00007f9093c9dc25 [0x00007f9093c9d960+0x00000000000002c5]
+ * J 95 c2 TestSynchronizedMethodWhenUnwindingDeopt.bar()V (14 bytes) @ 0x00007f9093c9a854 [0x00007f9093c9a840+0x0000000000000014]
+ */
+
+public class TestSynchronizedMethodWhenUnwindingDeopt {
+    private static WhiteBox WB = WhiteBox.getWhiteBox();
+
+    public static void main(String[] args) throws Exception {
+        new Thread(() -> {
+            for (int i = 0; i < 50; i++) {
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+                WB.deoptimizeAll();
+            }
+        }).start();
+        MultiThreadWispRunner.run(
+                "TestSynchronizedMethodWhenUnwindingDeopt",
+                4,
+                4,
+                200_000,
+                100000,
+                () -> bar(3));
+    }
+
+    private volatile static byte WRITE_VAL = 1;
+
+    // A will be inlined
+    private synchronized static void foo() {
+        for (int i = 0; i < bs.length; i++) {
+            bs[i] = WRITE_VAL;
+        }
+        if (bs[3] == WRITE_VAL)  throw new RuntimeException();  // It must unwind
+    }
+    private static void bar(int p) {
+        try {
+            foo();
+        } catch (RuntimeException e) {
+
+        } finally {
+
+        }
+    }
+
+    static byte[] bs = new byte[12];
+}


### PR DESCRIPTION
Summary: It has the possibility to get a deoptimization whenever entering into java code. 1. When this happens at calling Wisp.unpark at the bytecode _return of synchronized methods, it is going to crash or error because the origin deopt logic cannot handle the _return bytecode; 2. For synchronized blocks, the unlocked monitor shouldn't be recorded into the debuginfo so that an illegalMonitorStateException will be thrown out.

Test Plan: `test/jdk/com/alibaba/wisp/monitor/deopt/*`, which can reproduce this issue.

Reviewed-by: leiyul, kuaiwei

Issue: alibaba/dragonwell8#172