### PR TITLE
[Wisp] Enhance output of jstack for WispControlGroup related statistics

### DIFF
--- a/src/share/vm/classfile/javaClasses.cpp
+++ b/src/share/vm/classfile/javaClasses.cpp
@@ -3436,6 +3436,8 @@ int com_alibaba_wisp_engine_WispTask::_activeCount_offset = 0;
 int com_alibaba_wisp_engine_WispTask::_stealCount_offset = 0;
 int com_alibaba_wisp_engine_WispTask::_stealFailureCount_offset = 0;
 int com_alibaba_wisp_engine_WispTask::_preemptCount_offset = 0;
+int com_alibaba_wisp_engine_WispTask::_controlGroup_offset = 0;
+int com_alibaba_wisp_engine_WispTask::_ttr_offset = 0;
 
 void com_alibaba_wisp_engine_WispTask::compute_offsets() {
   Klass* k = SystemDictionary::com_alibaba_wisp_engine_WispTask_klass();
@@ -3449,6 +3451,8 @@ void com_alibaba_wisp_engine_WispTask::compute_offsets() {
   compute_offset(_stealCount_offset,    k, vmSymbols::stealCount_name(),      vmSymbols::int_signature());
   compute_offset(_stealFailureCount_offset, k, vmSymbols::stealFailureCount_name(), vmSymbols::int_signature());
   compute_offset(_preemptCount_offset,  k, vmSymbols::preemptCount_name(),    vmSymbols::int_signature());
+  compute_offset(_controlGroup_offset,  k, vmSymbols::controlGroup_name(), vmSymbols::com_alibaba_wisp_engine_WispControlGroup_signature());
+  compute_offset(_ttr_offset,           k, vmSymbols::ttr_name(),    vmSymbols::long_signature());
 }
 
 void com_alibaba_wisp_engine_WispTask::set_jvmParkStatus(oop obj, jint status) {
@@ -3497,6 +3501,44 @@ int com_alibaba_wisp_engine_WispTask::get_preemptCount(oop obj) {
 
 void com_alibaba_wisp_engine_WispTask::set_preemptCount(oop obj, jint count) {
   obj->int_field_put(_preemptCount_offset, count);
+}
+
+oop com_alibaba_wisp_engine_WispTask::get_controlGroup(oop obj) {
+  return obj->obj_field(_controlGroup_offset);
+}
+
+long com_alibaba_wisp_engine_WispTask::get_ttr(oop obj) {
+  return obj->long_field(_ttr_offset);
+}
+
+int com_alibaba_wisp_engine_WispControlGroup::_cpuLimit_offset = 0;
+
+void com_alibaba_wisp_engine_WispControlGroup::compute_offsets() {
+  Klass *k = SystemDictionary::com_alibaba_wisp_engine_WispControlGroup_klass();
+  assert(k != NULL, "WispControlGroup_klass is null");
+  compute_offset(_cpuLimit_offset, k, vmSymbols::cpuLimit_name(),   vmSymbols::com_alibaba_wisp_engine_WispControlGroup_CpuLimit_signature());
+}
+
+oop com_alibaba_wisp_engine_WispControlGroup::get_cpuLimit(oop obj) {
+  return obj->obj_field(_cpuLimit_offset);
+}
+
+int com_alibaba_wisp_engine_WispControlGroup_CpuLimit::_cfsPeriod_offset = 0;
+int com_alibaba_wisp_engine_WispControlGroup_CpuLimit::_cfsQuota_offset = 0;
+
+void com_alibaba_wisp_engine_WispControlGroup_CpuLimit::compute_offsets() {
+  Klass *k = SystemDictionary::com_alibaba_wisp_engine_WispControlGroup_CpuLimit_klass();
+  assert(k != NULL, "WispControlGroup$CpuLimit_klass is null");
+  compute_offset(_cfsPeriod_offset, k, vmSymbols::cfsPeriod_name(),   vmSymbols::long_signature());
+  compute_offset(_cfsQuota_offset, k, vmSymbols::cfsQuota_name(),   vmSymbols::long_signature());
+}
+
+long com_alibaba_wisp_engine_WispControlGroup_CpuLimit::get_cfsPeriod(oop obj) {
+  return obj->long_field(_cfsPeriod_offset);
+}
+
+long com_alibaba_wisp_engine_WispControlGroup_CpuLimit::get_cfsQuota(oop obj) {
+  return obj->long_field(_cfsQuota_offset);
 }
 
 void java_util_concurrent_locks_AbstractOwnableSynchronizer::initialize(TRAPS) {
@@ -3613,6 +3655,8 @@ void JavaClasses::compute_offsets() {
     java_dyn_CoroutineBase::compute_offsets();
     com_alibaba_wisp_engine_WispCarrier::compute_offsets();
     com_alibaba_wisp_engine_WispTask::compute_offsets();
+    com_alibaba_wisp_engine_WispControlGroup::compute_offsets();
+    com_alibaba_wisp_engine_WispControlGroup_CpuLimit::compute_offsets();
   }
 
   if(MultiTenant) {

--- a/src/share/vm/classfile/javaClasses.hpp
+++ b/src/share/vm/classfile/javaClasses.hpp
@@ -1521,6 +1521,8 @@ private:
   static int _stealCount_offset;
   static int _stealFailureCount_offset;
   static int _preemptCount_offset;
+  static int _controlGroup_offset;
+  static int _ttr_offset;
 public:
   static void set_jvmParkStatus(oop obj, jint status);
   static int  get_jvmParkStatus(oop obj);
@@ -1534,6 +1536,29 @@ public:
   static int  get_stealFailureCount(oop obj);
   static int  get_preemptCount(oop obj);
   static void set_preemptCount(oop obj, jint count);
+  static oop  get_controlGroup(oop obj);
+  static oop  get_cpuLimit(oop obj);
+  static long get_ttr(oop obj);
+
+  static void compute_offsets();
+};
+
+class com_alibaba_wisp_engine_WispControlGroup: AllStatic {
+private:
+  static int _cpuLimit_offset;
+public:
+  static oop  get_cpuLimit(oop obj);
+
+  static void compute_offsets();
+};
+
+class com_alibaba_wisp_engine_WispControlGroup_CpuLimit: AllStatic {
+private:
+  static int _cfsPeriod_offset;
+  static int _cfsQuota_offset;
+public:
+  static long get_cfsPeriod(oop obj);
+  static long get_cfsQuota(oop obj);
 
   static void compute_offsets();
 };

--- a/src/share/vm/classfile/systemDictionary.hpp
+++ b/src/share/vm/classfile/systemDictionary.hpp
@@ -211,6 +211,10 @@ class SymbolPropertyTable;
   do_klass(com_alibaba_wisp_engine_WispTask_klass,      com_alibaba_wisp_engine_WispTask,          Opt                 ) \
   do_klass(com_alibaba_wisp_engine_WispTask_CacheableCoroutine_klass,                                                    \
                                                         com_alibaba_wisp_engine_WispTask_CacheableCoroutine, Opt       ) \
+  do_klass(com_alibaba_wisp_engine_WispControlGroup_klass,                                                               \
+                                                        com_alibaba_wisp_engine_WispControlGroup_signature, Opt        ) \
+  do_klass(com_alibaba_wisp_engine_WispControlGroup_CpuLimit_klass,                                                      \
+                                                        com_alibaba_wisp_engine_WispControlGroup_CpuLimit_signature, Opt ) \
   do_klass(com_alibaba_wisp_engine_WispEngine_klass,    com_alibaba_wisp_engine_WispEngine,        Opt                 ) \
   do_klass(com_alibaba_wisp_engine_WispCarrier_klass,   com_alibaba_wisp_engine_WispCarrier,       Opt                 ) \
   do_klass(com_alibaba_wisp_engine_WispEventPump_klass, com_alibaba_wisp_engine_WispEventPump,     Opt                 ) \

--- a/src/share/vm/classfile/vmSymbols.hpp
+++ b/src/share/vm/classfile/vmSymbols.hpp
@@ -637,12 +637,21 @@
   template(com_alibaba_wisp_engine_WispTask,           "com/alibaba/wisp/engine/WispTask")                        \
   template(com_alibaba_wisp_engine_WispTask_CacheableCoroutine,                                                   \
                                                        "com/alibaba/wisp/engine/WispTask$CacheableCoroutine")     \
+  template(com_alibaba_wisp_engine_WispControlGroup_signature,                                                    \
+                                                       "Lcom/alibaba/wisp/engine/WispControlGroup;")              \
+  template(com_alibaba_wisp_engine_WispControlGroup_CpuLimit_signature,                                           \
+                                                       "Lcom/alibaba/wisp/engine/WispControlGroup$CpuLimit;")     \
   template(com_alibaba_wisp_engine_WispEngine,         "com/alibaba/wisp/engine/WispEngine")                      \
   template(com_alibaba_wisp_engine_WispCarrier,        "com/alibaba/wisp/engine/WispCarrier")                     \
   template(com_alibaba_wisp_engine_WispEventPump,      "com/alibaba/wisp/engine/WispEventPump")                   \
   template(isInCritical_name,                          "isInCritical")                                            \
   template(jdkParkStatus_name,                         "jdkParkStatus")                                           \
   template(jvmParkStatus_name,                         "jvmParkStatus")                                           \
+  template(ttr_name,                                   "ttr")                                                     \
+  template(controlGroup_name,                          "controlGroup")                                            \
+  template(cpuLimit_name,                              "cpuLimit")                                                \
+  template(cfsPeriod_name,                             "cfsPeriod")                                               \
+  template(cfsQuota_name,                              "cfsQuota")                                                \
   template(id_name,                                    "id")                                                      \
   template(threadWrapper_name,                         "threadWrapper")                                           \
   template(activeCount_name,                           "activeCount")                                             \

--- a/src/share/vm/runtime/coroutine.cpp
+++ b/src/share/vm/runtime/coroutine.cpp
@@ -503,14 +503,29 @@ oop Coroutine::print_stack_header_on(outputStream* st) {
         java_lang_String::as_utf8_string(name, buf, sizeof(buf));
       }
     }
-    st->print(" \"%s\" #%d active=%d steal=%d steal_fail=%d preempt=%d park=%d/%d", buf,
+    // calculate wisp container's cfs_period and cfs_quota
+    long cfsPeriod = 0;
+    long cfsQuota  = 0;
+    // step one: get WispControlGroup
+    oop wispControlGroup = com_alibaba_wisp_engine_WispTask::get_controlGroup(_wisp_task);
+    if (wispControlGroup != NULL) {
+      // step two: get CpuLimit
+      oop cpuLimit = com_alibaba_wisp_engine_WispControlGroup::get_cpuLimit(wispControlGroup);
+      guarantee(cpuLimit != NULL, "cpuLimit in WispControlGroup should not be null");
+      // step three: get cfsPeriod and cfsQuota
+      cfsPeriod = com_alibaba_wisp_engine_WispControlGroup_CpuLimit::get_cfsPeriod(cpuLimit);
+      cfsQuota  = com_alibaba_wisp_engine_WispControlGroup_CpuLimit::get_cfsQuota(cpuLimit);
+    }
+    st->print(" \"%s\" #%d active=%d steal=%d steal_fail=%d preempt=%d park=%d/%d cg=%ld/%ld ttr=%ld", buf,
         com_alibaba_wisp_engine_WispTask::get_id(_wisp_task),
         com_alibaba_wisp_engine_WispTask::get_activeCount(_wisp_task),
         com_alibaba_wisp_engine_WispTask::get_stealCount(_wisp_task),
         com_alibaba_wisp_engine_WispTask::get_stealFailureCount(_wisp_task),
         com_alibaba_wisp_engine_WispTask::get_preemptCount(_wisp_task),
         com_alibaba_wisp_engine_WispTask::get_jvmParkStatus(_wisp_task),
-        com_alibaba_wisp_engine_WispTask::get_jdkParkStatus(_wisp_task));
+        com_alibaba_wisp_engine_WispTask::get_jdkParkStatus(_wisp_task),
+        cfsQuota / 1000, cfsPeriod / 1000,
+        com_alibaba_wisp_engine_WispTask::get_ttr(_wisp_task));
   }
   if (_wisp_thread && PrintThreadCoroutineInfo) {
     st->print(" monitor_park_stage=%s", WispThread::print_blocking_status(_wisp_thread->_unpark_status));

--- a/test/runtime/coroutine/JStackWispControlGroupTest.java
+++ b/test/runtime/coroutine/JStackWispControlGroupTest.java
@@ -1,0 +1,192 @@
+/*
+ * @test
+ * @library /testlibrary
+ * @summary Test jstack ttr and container's cfs configuration.
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 -XX:ActiveProcessorCount=5 JStackWispControlGroupTest
+ */
+
+import com.alibaba.wisp.engine.WispTask;
+
+import java.dyn.CoroutineBase;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.concurrent.ExecutorService;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import sun.misc.SharedSecrets;
+import sun.misc.WispEngineAccess;
+import static com.oracle.java.testlibrary.Asserts.*;
+
+public class JStackWispControlGroupTest {
+    private static WispEngineAccess WEA = SharedSecrets.getWispEngineAccess();
+
+    private static Field ctx = null;
+    private static Field data = null;
+    private static Field ttr = null;
+    private static Field cfsPeriod = null;
+    private static Field cfsQuota = null;
+    private static Field cg = null;
+    private static Field cpuLimit = null;
+    private static Class<?> WispControlGroupClazz = null;
+    private static Class<?> CpuLimitClazz = null;
+
+    static {
+        try {
+            ctx = WispTask.class.getDeclaredField("ctx");
+            ctx.setAccessible(true);
+        } catch (NoSuchFieldException e) {
+            fail(e.getMessage());
+        }
+        try {
+            data = CoroutineBase.class.getDeclaredField("nativeCoroutine");
+            data.setAccessible(true);
+        } catch (NoSuchFieldException e) {
+            fail(e.getMessage());
+        }
+        try {
+            ttr = WispTask.class.getDeclaredField("ttr");
+            ttr.setAccessible(true);
+        } catch (NoSuchFieldException e) {
+            fail(e.getMessage());
+        }
+        try {
+            WispControlGroupClazz = Class.forName("com.alibaba.wisp.engine.WispControlGroup");
+            CpuLimitClazz = Class.forName("com.alibaba.wisp.engine.WispControlGroup$CpuLimit");
+            cg = WispTask.class.getDeclaredField("controlGroup");
+            cg.setAccessible(true);
+            cpuLimit = WispControlGroupClazz.getDeclaredField("cpuLimit");
+            cpuLimit.setAccessible(true);
+            cfsPeriod = CpuLimitClazz.getDeclaredField("cfsPeriod");
+            cfsPeriod.setAccessible(true);
+            cfsQuota = CpuLimitClazz.getDeclaredField("cfsQuota");
+            cfsQuota.setAccessible(true);
+        } catch (NoSuchFieldException | ClassNotFoundException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    private static Map<String, Long> ttrMap = new ConcurrentHashMap<>();
+    private static Map<String, Long> cfsPeriodMap = new ConcurrentHashMap<>();
+    private static Map<String, Long> cfsQuotaMap = new ConcurrentHashMap<>();
+
+    private static void test() throws Exception {
+
+        Method createMethod = WispControlGroupClazz.getDeclaredMethod("newInstance",
+                int.class);
+        createMethod.setAccessible(true);
+        ExecutorService contain = (ExecutorService) createMethod.invoke(null, 50);
+
+        int wispTaskCount = 200;
+
+        CountDownLatch latch0 = new CountDownLatch(wispTaskCount);
+        CountDownLatch latch1 = new CountDownLatch(1);
+        for (int i = 0; i < wispTaskCount; i++) {
+            contain.submit(() -> {
+                try {
+                    WispTask current = WEA.getCurrentTask();
+                    long coroutine = (Long) data.get(ctx.get(current));
+                    String name = "0x" + Long.toHexString(coroutine);
+                    ttrMap.put(name, (Long) ttr.get(current));
+                    cfsPeriodMap.put(name, (Long) cfsPeriod.get(cpuLimit.get(cg.get(current))));
+                    cfsQuotaMap.put(name, (Long) cfsQuota.get(cpuLimit.get(cg.get(current))));
+                } catch (IllegalAccessException e) {
+                    fail(e.getMessage());
+                } finally {
+                    try {
+                        latch0.countDown();
+                        latch1.await();
+                    } catch (InterruptedException e) {
+                        fail(e.getMessage());
+                    }
+                }
+            });
+        }
+
+        latch0.await();
+        List<String> result = jstack();
+        int checkedWisp = 0;
+        for (int i = 0; i < result.size(); i++) {
+            if (result.get(i).contains("- Coroutine [")) {
+                String str = result.get(i);
+                String coroutine = matchCoroutine(str);
+                long ttrV = Long.parseLong(matchttr(str));
+                Long ttrVM = ttrMap.get(coroutine);
+                long cfsPeriodV = Long.parseLong(matchPeriod(str));
+                long cfsQuotaV = Long.parseLong(matchQuota(str));
+                Long cfsVM = ttrMap.get(coroutine);
+                if (ttrVM != null && cfsVM != null) {
+                    assertEQ(ttrVM.longValue(), ttrV);
+                    assertEQ(cfsPeriodMap.get(coroutine).longValue(), cfsPeriodV * 1000);
+                    assertEQ(cfsQuotaMap.get(coroutine).longValue(), cfsQuotaV * 1000);
+                    checkedWisp++;
+                }
+            }
+        }
+        latch1.countDown();
+        assertEQ(checkedWisp, wispTaskCount);
+    }
+
+    private static String matchCoroutine(String str) {
+        Pattern pattern = Pattern.compile(".*\\[(.*)\\].*");
+        Matcher matcher = pattern.matcher(str);
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+        fail("ShouldNotReachHere");
+        return null;
+    }
+
+    private static String matchttr(String str) {
+        Pattern pattern = Pattern.compile(".*ttr=(\\d+).*");
+        Matcher matcher = pattern.matcher(str);
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+        fail("ShouldNotReachHere");
+        return null;
+    }
+
+    private static String matchQuota(String str) {
+        Pattern pattern = Pattern.compile(".*cg=(\\d+).*");
+        Matcher matcher = pattern.matcher(str);
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+        fail("ShouldNotReachHere");
+        return null;
+    }
+
+    private static String matchPeriod(String str) {
+        Pattern pattern = Pattern.compile(".*cg=[0-9]*/(\\d+).*");
+        Matcher matcher = pattern.matcher(str);
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+        fail("ShouldNotReachHere");
+        return null;
+    }
+
+    private static List<String> jstack() throws Exception {
+        List<String> statusLines = Files.readAllLines(Paths.get("/proc/self/status"));
+        String pidLine = statusLines.stream().filter(l -> l.startsWith("Pid:")).findAny().orElse("1 -1");
+        int pid = Integer.valueOf(pidLine.split("\\s+")[1]);
+
+        Process p = Runtime.getRuntime().exec(System.getProperty("java.home") + "/../bin/jstack " + pid);
+        List<String> result = new BufferedReader(new InputStreamReader(p.getInputStream())).lines()
+                .collect(Collectors.toList());
+        return result;
+    }
+
+    public static void main(String[] args) throws Exception {
+        test();
+    }
+}


### PR DESCRIPTION
Summary: Add more three fields in output of jstack, they are ttr/cfsPeriod/cfsQuota,
         which could help to debug wisp control group issues.

Test Plan: add ut JStackWispControlGroupTest.

Reviewers: lei.yul, sanhong.lsh, joeylee.lz

Issue: https://github.com/alibaba/dragonwell8/issues/183