### PR TITLE
[Wisp] make wisp task's stack space size traceable by NMT

### DIFF
--- a/src/share/vm/memory/allocation.hpp
+++ b/src/share/vm/memory/allocation.hpp
@@ -155,9 +155,12 @@ enum MemoryType {
   mtTest              = 0x0D,  // Test type for verifying NMT
   mtTracing           = 0x0E,  // memory used for Tracing
   mtTenant            = 0x0F,  // memory used by MultiTenant code
-  mtWisp              = 0x10,  // memory used by Wisp code
-  mtNone              = 0x11,  // undefined
-  mt_number_of_types  = 0x12   // number of memory types (mtDontTrack
+  mtWisp              = 0x10,  // memory used by Wisp code, such as WispResourceArea
+                               // _proxy_unpark SystemDictMonitor Coroutine CoroutineStack and so on
+  mtCoroutineStack    = 0x11,  // memory used by Wisp Coroutine Stack Space
+  mtCoroutine         = 0x12,  // memory used by Wisp Coroutine Wrapper
+  mtNone              = 0x13,  // undefined
+  mt_number_of_types  = 0x14   // number of memory types (mtDontTrack
                                  // is not included as validate type)
 };
 

--- a/src/share/vm/runtime/coroutine.cpp
+++ b/src/share/vm/runtime/coroutine.cpp
@@ -411,6 +411,8 @@ CoroutineStack* CoroutineStack::create_stack(JavaThread* thread, intptr_t size/*
   stack->_last_sp = NULL;
   stack->_default_size = default_size;
 
+  MemTracker::record_virtual_memory_type((address)stack->_reserved_space.base(), mtCoroutineStack);
+
   if (os::uses_stack_guard_pages()) {
     address low_addr = stack->stack_base() - stack->stack_size();
     size_t len = (StackYellowPages + StackRedPages) * os::vm_page_size();

--- a/src/share/vm/runtime/coroutine.hpp
+++ b/src/share/vm/runtime/coroutine.hpp
@@ -81,7 +81,7 @@ public:
 class WispPostStealHandleUpdateMark;
 class WispResourceArea;
 
-class Coroutine: public CHeapObj<mtThread>, public DoublyLinkedList<Coroutine> {
+class Coroutine: public CHeapObj<mtCoroutine>, public DoublyLinkedList<Coroutine> {
 public:
   enum CoroutineState {
     _created    = 0x00000000,      // not inited
@@ -251,7 +251,7 @@ public:
   static ByteSize wisp_thread_offset()        { return byte_offset_of(Coroutine, _wisp_thread); }
 };
 
-class CoroutineStack: public CHeapObj<mtThread>, public DoublyLinkedList<CoroutineStack> {
+class CoroutineStack: public CHeapObj<mtCoroutine>, public DoublyLinkedList<CoroutineStack> {
 private:
   JavaThread*     _thread;
 

--- a/src/share/vm/services/memReporter.cpp
+++ b/src/share/vm/services/memReporter.cpp
@@ -110,7 +110,8 @@ void MemSummaryReporter::report() {
   for (int index = 0; index < mt_number_of_types; index ++) {
     MEMFLAGS flag = NMTUtil::index_to_flag(index);
     // thread stack is reported as part of thread category
-    if (flag == mtThreadStack) continue;
+    if ((flag == mtThreadStack) ||
+        (!EnableCoroutine && (flag == mtWisp || flag == mtCoroutine || flag == mtCoroutineStack)))           continue;
     MallocMemory* malloc_memory = _malloc_snapshot->by_type(flag);
     VirtualMemory* virtual_memory = _vm_snapshot->by_type(flag);
 

--- a/src/share/vm/services/nmtCommon.cpp
+++ b/src/share/vm/services/nmtCommon.cpp
@@ -42,6 +42,8 @@ const char* NMTUtil::_memory_type_names[] = {
   "Tracing",
   "Tenant",
   "Wisp",
+  "CoroutineStack",
+  "Coroutine",
   "Unknown"
 };
 

--- a/test/runtime/coroutine/NmtTracingWispStackTest.java
+++ b/test/runtime/coroutine/NmtTracingWispStackTest.java
@@ -1,0 +1,55 @@
+/*
+ * @test
+ * @library /testlibrary
+ * @summary verification that NMT tracing Wisp Stack Memory statistics
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 -XX:ActiveProcessorCount=4 -XX:NativeMemoryTracking=summary NmtTracingWispStackTest
+ * @run main/othervm -XX:ActiveProcessorCount=4 -XX:NativeMemoryTracking=summary NmtTracingWispStackTest
+ */
+
+import java.util.Queue;
+import java.util.List;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.lang.management.ManagementFactory;
+
+import static com.oracle.java.testlibrary.Asserts.*;
+
+public class NmtTracingWispStackTest {
+    public static void main(String[] args) throws Exception {
+        List<String> result = jcmd();
+        int i = 0;
+        int flag = 0;
+        for (; i < result.size(); i++) {
+            if (result.get(i).contains("CoroutineStack") || result.get(i).contains("Coroutine")) {
+                flag++;
+            }
+        }
+
+        List<String> inputArguments = ManagementFactory.getRuntimeMXBean().getInputArguments();
+        if (inputArguments.contains("-XX:+UseWisp2")) {
+            assertEquals(flag, 2, "NMT trace output contains no CoroutineStack or Coroutine information");
+        } else {
+            assertEquals(flag, 0, "NMT trace output contains CoroutineStack or Coroutine information");
+        }
+    }
+
+    private static List<String> jcmd() throws Exception {
+        List<String> statusLines = Files.readAllLines(Paths.get("/proc/self/status"));
+        String pidLine = statusLines.stream().filter(l -> l.startsWith("Pid:")).findAny().orElse("1 -1");
+        int pid = Integer.valueOf(pidLine.split("\\s+")[1]);
+
+        Process p = Runtime.getRuntime()
+                .exec(System.getProperty("java.home") + "/../bin/jcmd " + pid + " VM.native_memory");
+        List<String> result = new BufferedReader(new InputStreamReader(p.getInputStream())).lines()
+                .collect(Collectors.toList());
+        return result;
+    }
+}


### PR DESCRIPTION
Summary:
refactor wisp task's jvm native memory utilization classification
and add a new native memory label for NMT.

Test Plan:
hotspot/test/runtime/coroutine/NmtTracingWispStackTest.java

Reviewed-by: lei.yul, sanhong.lsh, joeylee.lz

Issue: alibaba/dragonwell8#191