### PR TITLE
[Misc] Fix compilation error on aarch64

### DIFF
--- a/src/cpu/aarch64/vm/c1_LIRAssembler_aarch64.cpp
+++ b/src/cpu/aarch64/vm/c1_LIRAssembler_aarch64.cpp
@@ -193,6 +193,7 @@ Address LIR_Assembler::as_Address(LIR_Address* addr, Register tmp) {
 	return Address(base, index, Address::lsl(addr->scale()));
       default:
 	ShouldNotReachHere();
+        return Address();
       }
   } else  {
     intptr_t addr_offset = intptr_t(addr->disp());


### PR DESCRIPTION
Summary: add return statement after ShouldNotReachHere();

Test Plan: AdoptJDK CI pipeline

Reviewed-by: joeyleeeeeee97, yuleil

Issue: https://github.com/alibaba/dragonwell8/issues/199