### PR TITLE
[Wisp] Fix infinite loop at ThreadDump operation

### DIFF
--- a/src/share/vm/runtime/vm_operations.cpp
+++ b/src/share/vm/runtime/vm_operations.cpp
@@ -324,7 +324,7 @@ void VM_ThreadDump::doit() {
       ThreadSnapshot* ts = snapshot_thread(jt, tcl);
       _result->add_thread_snapshot(ts);
 
-      if (EnableCoroutine) {
+      if (EnableCoroutine && SafepointSynchronize::is_at_safepoint()) {
         for (Coroutine* co = jt->coroutine_list()->next();
             co != jt->coroutine_list(); co = co->next()) {
           oop tw = com_alibaba_wisp_engine_WispTask::get_threadWrapper(co->wisp_task());
@@ -355,7 +355,7 @@ void VM_ThreadDump::doit() {
         continue;
       }
 
-      if (EnableCoroutine) {
+      if (EnableCoroutine && SafepointSynchronize::is_at_safepoint()) {
         jlong id = java_lang_Thread::thread_id(th());
         // this would traverse thread's coroutine list
         JavaThread* jt = Threads::find_java_thread_from_java_tid(id);

--- a/src/share/vm/services/threadService.cpp
+++ b/src/share/vm/services/threadService.cpp
@@ -1003,7 +1003,7 @@ ThreadsListEnumerator::ThreadsListEnumerator(Thread* cur_thread,
       _threads_array->append(h);
     }
 
-    if (EnableCoroutine) {
+    if (EnableCoroutine && SafepointSynchronize::is_at_safepoint()) {
       for (Coroutine* co = jt->coroutine_list()->next(); co != jt->coroutine_list(); co = co->next()) {
         if (!ThreadsListEnumerator::skipThread(co->thread(), include_jvmti_agent_threads, include_jni_attaching_threads)) {
           oop tw = com_alibaba_wisp_engine_WispTask::get_threadWrapper(co->wisp_task());

--- a/test/runtime/coroutine/WispThreadMXBeanTest.java
+++ b/test/runtime/coroutine/WispThreadMXBeanTest.java
@@ -18,7 +18,6 @@ import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
-
 import com.oracle.java.testlibrary.*;
 import static com.oracle.java.testlibrary.Asserts.*;
 
@@ -31,6 +30,7 @@ public class WispThreadMXBeanTest {
 
     public static void main(String[] args) throws Exception {
         getStack();
+        getThreadInfo();
     }
 
     private static void getStack() throws Exception {
@@ -50,5 +50,27 @@ public class WispThreadMXBeanTest {
         System.out.println(i);
 
        done = true;
+    }
+
+    private static void getThreadInfo() throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+        Thread thread = new Thread(() -> {
+            latch.countDown();
+            while (true) {
+                try {
+                    Thread.sleep(20);
+                } catch (InterruptedException e) {
+                }
+            }
+        });
+        thread.start();
+
+        latch.await();
+        ThreadInfo[] infos = mbean.getThreadInfo(new long[]{thread.getId()}, 0);
+        StackTraceElement[] stack1 = thread.getStackTrace();
+        if (infos.length > 0) {
+            StackTraceElement[] stack2 = infos[0].getStackTrace();
+            assertTrue(Arrays.equals(stack1, stack2));
+        }
     }
 }


### PR DESCRIPTION
Summary: Chances are once coroutine stealing
happened in non safepoint time will lead to infinite loop.

Test Plan: jtreg test/runtime/coroutine

Reviewed-by: yuleil, zhengxiaolinX

Issue: https://github.com/alibaba/dragonwell8/issues/217