### PR TITLE
[Wisp] C1: Clear dead locals for MonitorExit that copies state to generate debuginfo

### DIFF
--- a/src/share/vm/c1/c1_LIRGenerator.cpp
+++ b/src/share/vm/c1/c1_LIRGenerator.cpp
@@ -454,13 +454,15 @@ CodeEmitInfo* LIRGenerator::state_for(Instruction* x, ValueStack* state, bool ig
 
     MethodLivenessResult liveness = method->liveness_at_bci(bci);
     if (bci == SynchronizationEntryBCI) {
-      if (x->as_ExceptionObject() || x->as_Throw()) {
+      // Wisp adds a OopMap by copying a state, which may contains dead oops because when
+      // bci == SynchronizationEntryBCI && x is MonitorExit we can determine it is the implicit
+      // monitorexit for the synchronized keyword of a synchronized method. We need to clear
+      // dead locals for it because no locals are needed at this time.
+      if (x->as_ExceptionObject() || x->as_Throw() || (UseWispMonitor && x->as_MonitorExit())) {
         // all locals are dead on exit from the synthetic unlocker
         liveness.clear();
       } else {
-        // In `LIRGenerator::do_MonitorExit()`, this function is called in support of wisp,
-        // when this is called in monitorexit, `x` will be a `MonitorExit` Instruction.
-        assert(x->as_MonitorEnter() || x->as_ProfileInvoke() || (UseWispMonitor && x->as_MonitorExit()), "only other cases are MonitorEnter and ProfileInvoke, or Wisp MonitorExit");
+        assert(x->as_MonitorEnter() || x->as_ProfileInvoke(), "only other cases are MonitorEnter and ProfileInvoke");
       }
     }
     if (!liveness.is_valid()) {

--- a/test/runtime/coroutine/deopt/TestSynchronizedMethodC1Crash.java
+++ b/test/runtime/coroutine/deopt/TestSynchronizedMethodC1Crash.java
@@ -1,0 +1,81 @@
+/*
+ * @test
+ * @summary Test MonitorExit nodes of synchronized methods for C1
+ * @library /testlibrary /testlibrary/whitebox
+ * @build sun.hotspot.WhiteBox
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox sun.hotspot.WhiteBox$WhiteBoxPermission
+ * @run main/othervm -XX:TieredStopAtLevel=1 -XX:CompileCommand=compileonly,TestSynchronizedMethodC1Crash::remove -XX:+PrintIR -XX:+PrintDeoptimizationDetails -XX:+IgnoreUnrecognizedVMOptions -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 TestSynchronizedMethodC1Crash
+ */
+
+
+import sun.hotspot.WhiteBox;
+
+/**
+ * Note: this method is imitating `io.vertx.sqlclient.impl.SocketConnectionBase::lambda\$init\$0`,
+ *   which can reproduce the crash at
+ *   LinearScan::resolve_exception_edge().
+ */
+
+public class TestSynchronizedMethodC1Crash {
+    private static WhiteBox WB = WhiteBox.getWhiteBox();
+
+    private static TestSynchronizedMethodC1Crash tsmcc = new TestSynchronizedMethodC1Crash();
+
+    public static void main(String[] args) throws Exception {
+        new Thread(() -> {
+            final long totalMillis = 20 * 500;
+            final long sleepMillis = 1;
+            for (int i = 0; i < totalMillis / sleepMillis; i++) {
+                try {
+                    Thread.sleep(sleepMillis);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+                // we are deoptimizing frames and do not mark the method not entrant.
+                // WB.deoptimizeAll();
+            }
+        }).start();
+        MultiThreadWispRunner.run(
+                "TestSynchronizedMethodC1Crash",
+                4,
+                4,
+                100_000,
+                100000,
+                () -> trampoline());
+    }
+
+    public static int i;
+    protected void handleClose(Throwable t) {
+        synchronized (this) {
+            if (t != null) {
+                t.getCause();
+            }
+        }
+    }
+    private synchronized void handleException(Throwable t) {
+        if (t instanceof NullPointerException) {
+            NullPointerException err = (NullPointerException) t;
+            t = err.getCause();
+        }
+        handleClose(t);
+    }
+    public void mayThrow() {
+        if (i++ % 1000 == 1) {
+            throw new NullPointerException();
+        } else {
+            // do nothing
+        }
+    }
+    public void remove() {
+        try {
+            mayThrow();
+        } catch (Exception e) {
+            handleException(e);
+        }
+    }
+
+    private static void trampoline() {
+        tsmcc.remove();
+    }
+
+}


### PR DESCRIPTION
Summary: MonitorExit introduces new 'State' to generate OopMaps and Debuginfo, yet dead locals on the 'State' doesn't get cleaned. We need to clean them because all locals are dead after the implicit monitorexit.

Test Plan: deopt/TestSynchronizedMethodC1Crash.java, which can reproduce this issue.

Reviewed-by: leiyul, sandlerwang, sanhong

Issue: https://github.com/alibaba/dragonwell8/issues/216