### PR TITLE
[Wisp] use global coroutine list instead of the coroutine list in eac…

### DIFF
--- a/src/cpu/x86/vm/sharedRuntime_x86_64.cpp
+++ b/src/cpu/x86/vm/sharedRuntime_x86_64.cpp
@@ -2364,7 +2364,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
   }
 
   if (EnableCoroutine) {
-    __ movptr(r11, Address(r15_thread, JavaThread::coroutine_list_offset()));
+    __ movptr(r11, Address(r15_thread, JavaThread::thread_coroutine_offset()));
     __ incrementl(Address(r11, Coroutine::native_call_counter_offset()));
   }
 

--- a/src/cpu/x86/vm/templateInterpreter_x86_64.cpp
+++ b/src/cpu/x86/vm/templateInterpreter_x86_64.cpp
@@ -1210,7 +1210,7 @@ address InterpreterGenerator::generate_native_entry(bool synchronized) {
 #endif
 
   if (EnableCoroutine) {
-    __ movptr(t, Address(r15_thread, JavaThread::coroutine_list_offset()));
+    __ movptr(t, Address(r15_thread, JavaThread::thread_coroutine_offset()));
     __ incrementl(Address(t, Coroutine::native_call_counter_offset()));
   }
 

--- a/src/share/vm/jfr/leakprofiler/checkpoint/rootResolver.cpp
+++ b/src/share/vm/jfr/leakprofiler/checkpoint/rootResolver.cpp
@@ -389,6 +389,13 @@ bool ReferenceToThreadRootClosure::do_java_threads_oops(JavaThread* jt) {
 
   ReferenceLocateClosure rcl(_callback, OldObjectRoot::_threads, OldObjectRoot::_global_jni_handle, jt);
   jt->oops_do(&rcl, NULL, NULL);
+  if (EnableCoroutine) {
+    ALL_JAVA_COROUTINES(c) {
+      if (c->thread() == jt) {
+        c->oops_do(&rcl, NULL, NULL);
+      }
+    }
+  }
   return rcl.complete();
 }
 

--- a/src/share/vm/prims/jvm.cpp
+++ b/src/share/vm/prims/jvm.cpp
@@ -3567,7 +3567,7 @@ JVM_QUICK_ENTRY(jboolean, JVM_IsInSameNative(JNIEnv* env, jobject jthread))
   // the thread is in native status and the native call counter isn't changed during two calls
   // then return true
   if (thr != NULL && thr->thread_state() == _thread_in_native) {
-    Coroutine* coro = thr->coroutine_list();
+    Coroutine* coro = thr->thread_coroutine();
     assert(coro != NULL, "coroutine list");
     if (coro->last_native_call_counter() == coro->native_call_counter()) {
       return JNI_TRUE;

--- a/src/share/vm/runtime/arguments.cpp
+++ b/src/share/vm/runtime/arguments.cpp
@@ -4146,6 +4146,12 @@ jint Arguments::parse(const JavaVMInitArgs* args) {
   }
 #endif
 
+  if (EnableCoroutine && UseParallelGC) {
+    warning("ParallelGC is not supported with Wisp"
+            "; ignoring EnableCoroutine flag." );
+    FLAG_SET_DEFAULT(EnableCoroutine, false);
+    FLAG_SET_DEFAULT(UseWispMonitor, false);
+  }
   // Set object alignment values.
   set_object_alignment();
 

--- a/src/share/vm/runtime/safepoint.cpp
+++ b/src/share/vm/runtime/safepoint.cpp
@@ -692,6 +692,10 @@ void SafepointSynchronize::do_cleanup_tasks() {
     TraceTime t7("purging class loader data graph", TraceSafepointCleanupTime);
     ClassLoaderDataGraph::purge_if_needed();
   }
+
+  if (EnableCoroutine) {
+    Coroutine::delete_exited_coroutines();
+  }
 }
 
 

--- a/src/share/vm/runtime/thread.hpp
+++ b/src/share/vm/runtime/thread.hpp
@@ -984,14 +984,14 @@ class JavaThread: public Thread {
   int _frames_to_pop_failed_realloc;
 
   // coroutine support
-  Coroutine*        _coroutine_list;
+  Coroutine*        _thread_coroutine;
   Coroutine*        _current_coroutine;
   bool              _wisp_preempted;
 
   intptr_t          _coroutine_temp;
 
  public:
-  Coroutine*& coroutine_list()                   { return _coroutine_list; }
+  Coroutine* thread_coroutine()                   { return _thread_coroutine; }
   Coroutine* current_coroutine()                 { return _current_coroutine; }
   void set_current_coroutine(Coroutine *coro)    { _current_coroutine = coro; }
   bool wisp_preempted() const                    { return _wisp_preempted; }
@@ -1454,7 +1454,7 @@ class JavaThread: public Thread {
   static ByteSize stack_guard_state_offset()     { return byte_offset_of(JavaThread, _stack_guard_state   ); }
   static ByteSize suspend_flags_offset()         { return byte_offset_of(JavaThread, _suspend_flags       ); }
   static ByteSize java_call_counter_offset()     { return byte_offset_of(JavaThread, _java_call_counter); }
-  static ByteSize coroutine_list_offset()        { return byte_offset_of(JavaThread, _coroutine_list); }
+  static ByteSize thread_coroutine_offset()        { return byte_offset_of(JavaThread, _thread_coroutine); }
 
   static ByteSize do_not_unlock_if_synchronized_offset() { return byte_offset_of(JavaThread, _do_not_unlock_if_synchronized); }
   static ByteSize should_post_on_exceptions_flag_offset() {

--- a/test/runtime/coroutine/MemLeakTest.java
+++ b/test/runtime/coroutine/MemLeakTest.java
@@ -50,6 +50,7 @@ public class MemLeakTest {
             t.join();
         }
 
+
         int rss0 = getRssInKb();
         System.out.println(rss0);
 
@@ -78,7 +79,6 @@ public class MemLeakTest {
             Coroutine target =  new Coroutine(r);
             Coroutine.yieldTo(target); // switch to new created coroutine and let it die
         }
-
         int rss0 = getRssInKb();
         System.out.println(rss0);
 


### PR DESCRIPTION
…h thread

Summary:
Currently, we need to add a lock when we steal a coroutine.
If the lock can't be got, the stealing failed.
Use global coroutine list to avoid the moving in coroutine list.
When we steal the coroutine, we only set the thread in the coroutine.
With the change, the success rate has been greatly increased.

Test Plan: all wisp cases

Reviewed-by: lei.yul, zhengxiaolinX

Issue: alibaba/dragonwell8#227