### PR TITLE
[Wisp] Support AArch64 platform based on the latest AArch64 port

### DIFF
--- a/src/cpu/aarch64/vm/aarch64.ad
+++ b/src/cpu/aarch64/vm/aarch64.ad
@@ -3373,6 +3373,11 @@ encode %{
       __ add(tmp, disp_hdr, (ObjectMonitor::owner_offset_in_bytes()-markOopDesc::monitor_value));
       __ mov(disp_hdr, zr);
 
+      if (UseWispMonitor) {
+        __ ldr (rthread, Address(rthread, JavaThread::current_coroutine_offset()));
+        __ ldr (rthread, Address(rthread, Coroutine::wisp_thread_offset()));
+      }
+
       if (UseLSE) {
         __ mov(rscratch1, disp_hdr);
         __ casal(Assembler::xword, rscratch1, rthread, tmp);
@@ -3389,6 +3394,10 @@ encode %{
 	__ stlxr(rscratch1, rthread, tmp);
 	__ cbnzw(rscratch1, retry_load);
 	__ bind(fail);
+      }
+
+      if (UseWispMonitor) {
+        __ ldr (rthread, Address(rthread, WispThread::thread_offset()));
       }
 
       // Store a non-null value into the box to avoid looking like a re-entrant
@@ -3469,7 +3478,14 @@ encode %{
       __ add(tmp, tmp, -markOopDesc::monitor_value); // monitor
       __ ldr(rscratch1, Address(tmp, ObjectMonitor::owner_offset_in_bytes()));
       __ ldr(disp_hdr, Address(tmp, ObjectMonitor::recursions_offset_in_bytes()));
+      if (UseWispMonitor) {
+        __ ldr (rthread, Address(rthread, JavaThread::current_coroutine_offset()));
+        __ ldr (rthread, Address(rthread, Coroutine::wisp_thread_offset()));
+      }
       __ eor(rscratch1, rscratch1, rthread); // Will be 0 if we are the owner.
+      if (UseWispMonitor) {
+        __ ldr (rthread, Address(rthread, WispThread::thread_offset()));
+      }
       __ orr(rscratch1, rscratch1, disp_hdr); // Will be 0 if there are 0 recursions
       __ cmp(rscratch1, zr);
       __ br(Assembler::NE, cont);
@@ -13909,6 +13925,25 @@ instruct tlsLoadP(thread_RegP dst)
 
   ins_pipe(pipe_class_empty);
 %}
+
+// Thread refetch:
+// take two main arguments:
+// 1. register @rthread
+// 2. one register which contains the `Coroutine *`
+// and move Coroutine->_thread to @rthread
+instruct tlsRefetchP(thread_RegP dst, iRegP src)
+%{
+  match(Set dst (ThreadRefetch src));
+
+  format %{ "Refetch the rthread register" %}
+
+  ins_encode %{
+  __ ldr(rthread, Address($src$$Register, Coroutine::thread_offset()));
+  %}
+
+  ins_pipe(pipe_class_empty);
+%}
+
 
 // ====================VECTOR INSTRUCTIONS=====================================
 

--- a/src/cpu/aarch64/vm/c1_LIRAssembler_aarch64.cpp
+++ b/src/cpu/aarch64/vm/c1_LIRAssembler_aarch64.cpp
@@ -426,7 +426,7 @@ int LIR_Assembler::emit_unwind_handler() {
   MonitorExitStub* stub = NULL;
   if (method()->is_synchronized()) {
     monitor_address(0, FrameMap::r0_opr);
-    stub = new MonitorExitStub(FrameMap::r0_opr, true, 0);
+    stub = new MonitorExitStub(FrameMap::r0_opr, true, 0, NULL, true);
     __ unlock_object(r5, r4, r0, *stub->entry());
     __ bind(*stub->continuation());
   }
@@ -2588,6 +2588,13 @@ void LIR_Assembler::emit_lock(LIR_OpLock* op) {
     Unimplemented();
   }
   __ bind(*op->stub()->continuation());
+  // add an OopMap here.
+  if (UseWispMonitor && op->code() == lir_unlock && !op->at_method_return()) {
+    // For direct unpark in Wisp, _info must be recorded to generate the oopmap.
+    guarantee(op->info() != NULL, "aarch64 needs an OopMap because the adr(lr, ...), so pc will be searched for the OopMap");
+    add_call_info_here(op->info());
+    verify_oop_map(op->info());
+  }
 }
 
 

--- a/src/cpu/aarch64/vm/c1_LIRGenerator_aarch64.cpp
+++ b/src/cpu/aarch64/vm/c1_LIRGenerator_aarch64.cpp
@@ -427,7 +427,18 @@ void LIRGenerator::do_MonitorExit(MonitorExit* x) {
   LIR_Opr lock = new_register(T_INT);
   LIR_Opr obj_temp = new_register(T_INT);
   set_no_result(x);
-  monitor_exit(obj_temp, lock, syncTempOpr(), LIR_OprFact::illegalOpr, x->monitor_no());
+  // Info is used to generate the oopmap, which is necessary for calling java code during runtime.
+  if (UseWispMonitor) {
+    CodeEmitInfo *info = NULL;
+    if (x->state()) {
+      info = state_for(x, x->state(), true);
+    }
+    // add info_for_exception CodeInfo here.
+    CodeEmitInfo *info_for_exception = state_for(x, x->state(), true);
+    monitor_exit(obj_temp, lock, syncTempOpr(), LIR_OprFact::illegalOpr, x->monitor_no(), info_for_exception, info, x->at_method_return());
+  } else {
+    monitor_exit(obj_temp, lock, syncTempOpr(), LIR_OprFact::illegalOpr, x->monitor_no());
+  }
 }
 
 

--- a/src/cpu/aarch64/vm/coroutine_aarch64.cpp
+++ b/src/cpu/aarch64/vm/coroutine_aarch64.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2020 Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation. Alibaba designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "prims/privilegedStack.hpp"
+#include "runtime/coroutine.hpp"
+#include "runtime/globals.hpp"
+#include "runtime/objectMonitor.hpp"
+#include "runtime/objectMonitor.inline.hpp"
+#include "services/threadService.hpp"
+
+#include "coroutine_aarch64.hpp"
+#include "vmreg_aarch64.hpp"
+
+void Coroutine::set_coroutine_base(intptr_t **&base, JavaThread* thread, jobject obj, Coroutine *coro, oop coroutineObj, address coroutine_start) {
+  *(--base) = (intptr_t*)obj;
+  *(--base) = (intptr_t*)coro;
+  *(--base) = NULL;
+  *(--base) = (intptr_t*)coroutine_start;
+  *(--base) = NULL;
+  // we need one more pointer space compared to x86:
+  // see `create_switchTo_contents()`, which will push both `lr` and `rfp` onto the stack.
+  // rfp will be saved to this space, which will be the end of gc backtrace.
+  *(--base) = NULL;
+}
+
+Register CoroutineStack::get_fp_reg() {
+  return rfp;
+}

--- a/src/cpu/aarch64/vm/coroutine_aarch64.hpp
+++ b/src/cpu/aarch64/vm/coroutine_aarch64.hpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2020 Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation. Alibaba designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef CPU_AARCH64_VM_COROUTINE_AARCH64_HPP
+#define CPU_AARCH64_VM_COROUTINE_AARCH64_HPP
+
+#define R_TH rthread
+// the below `thread` lays on the stack: something like
+// `const Address thread(rfp, thread_off * wordSize);`
+#define WISP_j2v_UPDATE __ str(R_TH, thread)
+
+#endif // CPU_AARCH64_VM_COROUTINE_AARCH64_HPP

--- a/src/cpu/aarch64/vm/macroAssembler_aarch64.hpp
+++ b/src/cpu/aarch64/vm/macroAssembler_aarch64.hpp
@@ -712,6 +712,7 @@ public:
 
   void get_vm_result  (Register oop_result, Register thread);
   void get_vm_result_2(Register metadata_result, Register thread);
+  void get_vm_result_for_wisp(Register oop_result, Register thread);
 
   // These always tightly bind to MacroAssembler::call_VM_base
   // bypassing the virtual implementation

--- a/src/cpu/aarch64/vm/sharedRuntime_aarch64.cpp
+++ b/src/cpu/aarch64/vm/sharedRuntime_aarch64.cpp
@@ -42,6 +42,10 @@
 #include "opto/runtime.hpp"
 #endif
 
+#include "runtime/coroutine.hpp"
+
+void coroutine_start(Coroutine* coroutine, jobject coroutineObj);
+
 #define __ masm->
 
 const int StackAlignmentInSlots = StackAlignmentInBytes / VMRegImpl::stack_slot_size;
@@ -1191,6 +1195,22 @@ static void gen_special_dispatch(MacroAssembler* masm,
                                                  receiver_reg, member_reg, /*for_compiler_entry:*/ true);
 }
 
+void create_switchTo_contents(MacroAssembler *masm, int start, OopMapSet* oop_maps, int &stack_slots, int total_in_args, BasicType *in_sig_bt, VMRegPair *in_regs, BasicType ret_type, bool terminate);
+
+void generate_thread_fix(MacroAssembler *masm, Method *method) {
+  // we can have a check here at the codegen time, so no cost in runtime.
+  if (EnableCoroutine) {
+    if (WispStealCandidate(method->method_holder()->name(), method->name(), method->signature()).is_steal_candidate()) {
+      // as aarch64 calling conventions, the thread register r28 is one of the callee saved registers.
+      // r19~r28 are callee-saved-registers. See StubRoutines::generate_call_stub()'s callee-saved-register restoration.
+      // the r28 register will be saved at method entry and restored implicitly at method exit
+      // so we have to fix it manually after the method returns.
+      // REF: https://developer.arm.com/docs/den0024/latest/the-abi-for-arm-64-bit-architecture/register-use-in-the-aarch64-procedure-call-standard/parameters-in-general-purpose-registers
+      WISP_CALLING_CONVENTION_V2J_UPDATE;
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Generate a native wrapper for a given method.  The method takes arguments
 // in the Java compiled code convention, marshals them to the native
@@ -1472,6 +1492,16 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     __ bang_stack_with_offset(StackShadowPages*os::vm_page_size());
   } else {
     Unimplemented();
+  }
+
+  if (EnableCoroutine) {
+    // the coroutine support methods have a hand-coded fast version that will handle the most common cases
+    if (method->intrinsic_id() == vmIntrinsics::_switchTo) {
+      create_switchTo_contents(masm, start, oop_maps, stack_slots, total_in_args, in_sig_bt, in_regs, ret_type, false);
+    } else if (method->intrinsic_id() == vmIntrinsics::_switchToAndTerminate ||
+      method->intrinsic_id() == vmIntrinsics::_switchToAndExit) {
+      create_switchTo_contents(masm, start, oop_maps, stack_slots, total_in_args, in_sig_bt, in_regs, ret_type, true);
+    }
   }
 
   // Generate a new frame for the wrapper.
@@ -1764,6 +1794,13 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     __ lea(c_rarg0, Address(rthread, in_bytes(JavaThread::jni_environment_offset())));
   }
 
+  if (EnableCoroutine) {
+    __ ldr(rscratch2, Address(rthread, JavaThread::coroutine_list_offset()));
+    __ lea(rscratch2, Address(rscratch2, Coroutine::native_call_counter_offset()));
+    // we couldn't use rscratch1 because `incrementw` will use rscratch1
+    __ incrementw(Address(rscratch2));
+  }
+
   // Now set thread in native
   __ mov(rscratch1, _thread_in_native);
   __ lea(rscratch2, Address(rthread, JavaThread::thread_state_offset()));
@@ -1801,6 +1838,11 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 
   intptr_t return_pc = (intptr_t) __ pc();
   oop_maps->add_gc_map(return_pc - start, map);
+
+  // In wisp, this coroutine may be stolen by another thread inside the `native_func` call.
+  // If this `native_func` is one of the several native functions we supported,
+  // we will add thread fix code for them.
+  generate_thread_fix(masm, method());
 
   // Unpack native results.
   switch (ret_type) {
@@ -1977,6 +2019,25 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     __ cbnz(rscratch1, exception_pending);
   }
 
+  // Return
+  if (EnableCoroutine &&
+       (method->intrinsic_id() == vmIntrinsics::_switchToAndTerminate ||
+        method->intrinsic_id() == vmIntrinsics::_switchToAndExit)) {
+
+    Label normal;
+    __ lea(rscratch1, RuntimeAddress((unsigned char*)coroutine_start));
+    __ ldr(rscratch2, Address(sp, 0));
+    __ cmp(rscratch2, rscratch1);
+    __ br(Assembler::NE, normal);
+
+    __ ldr(c_rarg0, Address(sp, HeapWordSize * 2));
+    __ ldr(c_rarg1, Address(sp, HeapWordSize * 3));
+
+    __ bind(normal);
+
+    __ ret(lr);        // <-- this will jump to the stored IP of the target coroutine
+  }
+
   // We're done
   __ ret(lr);
 
@@ -2010,6 +2071,11 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     __ call_VM_leaf(CAST_FROM_FN_PTR(address, SharedRuntime::complete_monitor_locking_C), 3);
     restore_args(masm, total_c_args, c_arg, out_regs);
 
+    if (EnableCoroutine) {
+      // the rthread has been restored in restore_args so we need to fix it.
+      WISP_COMPILER_RESTORE_FORCE_UPDATE;
+    }
+
 #ifdef ASSERT
     { Label L;
       __ ldr(rscratch1, Address(rthread, in_bytes(Thread::pending_exception_offset())));
@@ -2040,7 +2106,12 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     __ ldr(r19, Address(rthread, in_bytes(Thread::pending_exception_offset())));
     __ str(zr, Address(rthread, in_bytes(Thread::pending_exception_offset())));
 
-    rt_call(masm, CAST_FROM_FN_PTR(address, SharedRuntime::complete_monitor_unlocking_C), 2, 0, 1);
+    if (UseWispMonitor) {
+      __ mov(c_rarg2, rthread);
+      rt_call(masm, CAST_FROM_FN_PTR(address, SharedRuntime::complete_wisp_monitor_unlocking_C), 3, 0, 1);
+    } else {
+      rt_call(masm, CAST_FROM_FN_PTR(address, SharedRuntime::complete_monitor_unlocking_C), 2, 0, 1);
+    }
 
 #ifdef ASSERT
     {
@@ -3002,3 +3073,180 @@ void OptoRuntime::generate_exception_blob() {
   _exception_blob =  ExceptionBlob::create(&buffer, oop_maps, SimpleRuntimeFrame::framesize >> 1);
 }
 #endif // COMPILER2
+
+
+void create_switchTo_contents(MacroAssembler *masm, int start, OopMapSet* oop_maps, int &stack_slots, int total_in_args,
+                              BasicType *in_sig_bt, VMRegPair *in_regs, BasicType ret_type, bool terminate) {
+  assert(total_in_args == 2, "wrong number of arguments");
+
+  // unlike x86, something like TemplateTable::prepare_invoke() will
+  // generate the return ip into lr register instead of pushing
+  // on to the stack in x86.
+
+  // push the ip and frame pointer onto the stack
+  __ push(RegSet::of(lr, rfp), sp);
+
+  Register thread = rthread;
+  Register target_coroutine = j_rarg1;
+  // check that we're dealing with sane objects...
+  __ ldr(target_coroutine, Address(target_coroutine, java_dyn_CoroutineBase::get_data_offset()));
+
+  Register temp = r4;
+  Register temp2 = r5;
+  {
+    //////////////////////////////////////////////////////////////////////////
+    // store information into the old coroutine's object
+    //
+    // valid registers: rsi = old Coroutine, rdx = target Coroutine
+
+    Register old_coroutine_obj = j_rarg0;
+    Register old_coroutine = r5;
+    Register old_stack = r6;
+
+    // check that we're dealing with sane objects...
+    __ ldr(old_coroutine, Address(old_coroutine_obj, java_dyn_CoroutineBase::get_data_offset()));
+    __ ldr(old_stack, Address(old_coroutine, Coroutine::stack_offset()));
+
+    __ movw(temp, Coroutine::_onstack);
+    __ strw(temp, Address(old_coroutine, Coroutine::state_offset()));
+
+    // rescue old handle and resource areas
+    __ ldr(temp, Address(thread, Thread::handle_area_offset()));
+    __ str(temp, Address(old_coroutine, Coroutine::handle_area_offset()));
+    __ ldr(temp, Address(thread, Thread::resource_area_offset()));
+    __ str(temp, Address(old_coroutine, Coroutine::resource_area_offset()));
+    __ ldr(temp, Address(thread, Thread::last_handle_mark_offset()));
+    __ str(temp, Address(old_coroutine, Coroutine::last_handle_mark_offset()));
+    __ ldr(temp, Address(thread, Thread::active_handles_offset()));
+    __ str(temp, Address(old_coroutine, Coroutine::active_handles_offset()));
+    __ ldr(temp, Address(thread, Thread::metadata_handles_offset()));
+    __ str(temp, Address(old_coroutine, Coroutine::metadata_handles_offset()));
+    __ ldr(temp, Address(thread, JavaThread::last_Java_pc_offset()));
+    __ str(temp, Address(old_coroutine, Coroutine::last_Java_pc_offset()));
+    __ ldr(temp, Address(thread, JavaThread::last_Java_sp_offset()));
+    __ str(temp, Address(old_coroutine, Coroutine::last_Java_sp_offset()));
+    __ ldr(temp, Address(thread, JavaThread::privileged_stack_top_offset()));
+    __ str(temp, Address(old_coroutine, Coroutine::privileged_stack_top_offset()));
+    __ ldr(temp, Address(thread, JavaThread::threadObj_offset()));
+    __ ldrw(temp, Address(temp, java_lang_Thread::thread_status_offset()));
+    __ strw(temp, Address(old_coroutine, Coroutine::thread_status_offset()));
+    __ ldrw(temp, Address(thread, JavaThread::java_call_counter_offset()));
+    __ strw(temp, Address(old_coroutine, Coroutine::java_call_counter_offset()));
+    __ mov(temp, sp);
+    __ str(temp, Address(old_stack, CoroutineStack::last_sp_offset())); // str cannot use sp as an argument
+  }
+  Register target_stack = rheapbase;
+  __ ldr(target_stack, Address(target_coroutine, Coroutine::stack_offset()));
+
+  {
+    //////////////////////////////////////////////////////////////////////////
+    // perform the switch to the new stack
+    //
+    // valid registers: rdx = target Coroutine
+
+    __ movw(temp, Coroutine::_current);
+    __ strw(temp, Address(target_coroutine, Coroutine::state_offset()));
+    {
+      Register thread = rthread;
+      __ str(target_coroutine, Address(thread, JavaThread::current_coroutine_offset()));
+      // set new handle and resource areas
+      __ ldr(temp, Address(target_coroutine, Coroutine::handle_area_offset()));
+      __ str(temp, Address(thread, Thread::handle_area_offset()));
+      __ ldr(temp, Address(target_coroutine, Coroutine::resource_area_offset()));
+      __ str(temp, Address(thread, Thread::resource_area_offset()));
+      __ ldr(temp, Address(target_coroutine, Coroutine::last_handle_mark_offset()));
+      __ str(temp, Address(thread, Thread::last_handle_mark_offset()));
+      __ ldr(temp, Address(target_coroutine, Coroutine::active_handles_offset()));
+      __ str(temp, Address(thread, Thread::active_handles_offset()));
+      __ ldr(temp, Address(target_coroutine, Coroutine::metadata_handles_offset()));
+      __ str(temp, Address(thread, Thread::metadata_handles_offset()));
+      __ ldr(temp, Address(target_coroutine, Coroutine::last_Java_pc_offset()));
+      __ str(temp, Address(thread, JavaThread::last_Java_pc_offset()));
+      __ ldr(temp, Address(target_coroutine, Coroutine::last_Java_sp_offset()));
+      __ str(temp, Address(thread, JavaThread::last_Java_sp_offset()));
+      __ ldr(temp, Address(target_coroutine, Coroutine::privileged_stack_top_offset()));
+      __ str(temp, Address(thread, JavaThread::privileged_stack_top_offset()));
+      __ ldrw(temp2, Address(target_coroutine, Coroutine::thread_status_offset()));
+      __ ldr(temp, Address(thread, JavaThread::threadObj_offset()));
+      __ strw(temp2, Address(temp, java_lang_Thread::thread_status_offset()));
+      __ ldrw(temp, Address(target_coroutine, Coroutine::java_call_counter_offset()));
+      __ strw(temp, Address(thread, JavaThread::java_call_counter_offset()));
+#ifdef ASSERT
+      __ str(zr, Address(target_coroutine, Coroutine::handle_area_offset()));
+      __ str(zr, Address(target_coroutine, Coroutine::resource_area_offset()));
+      __ str(zr, Address(target_coroutine, Coroutine::last_handle_mark_offset()));
+      __ strw(zr, Address(target_coroutine, Coroutine::java_call_counter_offset()));
+#endif
+
+      // update the thread's stack base and size
+      __ ldr(temp, Address(target_stack, CoroutineStack::stack_base_offset()));
+      __ str(temp, Address(thread, JavaThread::stack_base_offset()));
+      __ ldrw(temp2, Address(target_stack, CoroutineStack::stack_size_offset()));
+      __ strw(temp2, Address(thread, JavaThread::stack_size_offset()));
+    }
+    // restore the stack pointer
+    __ ldr(temp, Address(target_stack, CoroutineStack::last_sp_offset()));
+
+    __ mov(sp, temp);
+
+    __ pop(RegSet::of(lr, rfp), sp);
+
+    if (!terminate) {
+      //////////////////////////////////////////////////////////////////////////
+      // normal case (resume immediately)
+
+      // this will reset r27
+      __ reinit_heapbase();
+
+#ifdef ASSERT
+      {
+        // bomb: clear all temp regs which are used in create_switchTo_contents()
+        __ mov(r0, zr);
+        __ mov(r1, zr);
+        __ mov(r2, zr);
+        __ mov(r3, zr);
+        __ mov(r4, zr);
+        __ mov(r5, zr);
+        __ mov(r6, zr);
+      }
+#endif
+
+      Label normal;
+      __ lea(rscratch1, RuntimeAddress((unsigned char*)coroutine_start));
+      __ ldr(rscratch2, Address(sp, 0));
+      __ cmp(rscratch2, rscratch1);
+      __ br(Assembler::NE, normal);
+
+      // set up the anchor: return address
+      // lr is 0 now, which is popped from stack settled by create_coroutine()
+      __ mov(lr, rscratch1);
+      // set up the coroutine_start() arguments
+      __ ldr(c_rarg0, Address(sp, HeapWordSize * 2));
+      __ ldr(c_rarg1, Address(sp, HeapWordSize * 3));
+
+      __ bind(normal);
+
+      // if the target coroutine is not the first time running (start from coroutine_start)
+      // it will jump directly to
+      // <interpreter>
+      //  TemplateInterpreterGenerator::generate_return_entry_for() stub after unsafeSymmetricYieldTo(),
+      //  and then load the args thru explicit generated bytecodes aload_0 of `this` and aload_N of other args.
+      // <compiler>
+      //  unsafeSymmetricYieldTo()'s nmethod which is compiled by C1/C2. Because bytecodes aload_0 and aload_N
+      //  is generated by javac, so argument registers will be saved on stack before unsafeSymmetricYieldTo()
+      //  and restored back after it.
+      // So it's safe to bzero all registers we used here.
+
+      __ ret(lr);        // <-- this will jump to the stored IP of the target coroutine
+
+    } else {
+      //////////////////////////////////////////////////////////////////////////
+      // slow case (terminate old coroutine)
+
+      // this will reset r27
+      __ reinit_heapbase();
+
+      __ movptr(j_rarg1, 0);
+    }
+  }
+}

--- a/src/cpu/aarch64/vm/stubGenerator_aarch64.cpp
+++ b/src/cpu/aarch64/vm/stubGenerator_aarch64.cpp
@@ -321,6 +321,15 @@ class StubGenerator: public StubCodeGenerator {
     // pop parameters
     __ sub(esp, rfp, -sp_after_call_off * wordSize);
 
+    if (EnableCoroutine) {
+      Label L;    // the steal thread patch
+      __ ldr(rscratch1, thread);
+      __ cmp(rthread, rscratch1);
+      __ br(Assembler::EQ, L);
+      WISP_j2v_UPDATE;
+      __ bind(L);
+    }
+
 #ifdef ASSERT
     // verify that threads correspond
     {
@@ -395,6 +404,11 @@ class StubGenerator: public StubCodeGenerator {
     // same as in generate_call_stub():
     const Address sp_after_call(rfp, sp_after_call_off * wordSize);
     const Address thread        (rfp, thread_off         * wordSize);
+
+    if (EnableCoroutine) {
+      // to pass the assertion fail
+      WISP_j2v_UPDATE;
+    }
 
 #ifdef ASSERT
     // verify that threads correspond

--- a/src/cpu/aarch64/vm/templateInterpreter_aarch64.cpp
+++ b/src/cpu/aarch64/vm/templateInterpreter_aarch64.cpp
@@ -1087,6 +1087,12 @@ address InterpreterGenerator::generate_native_entry(bool synchronized) {
   }
 #endif
 
+  if (EnableCoroutine) {
+    __ ldr(t, Address(rthread, JavaThread::coroutine_list_offset()));
+    __ lea(t, Address(t, Coroutine::native_call_counter_offset()));
+    __ incrementw(Address(t));
+  }
+
   // Change state to native
   __ mov(rscratch1, _thread_in_native);
   __ lea(rscratch2, Address(rthread, JavaThread::thread_state_offset()));
@@ -1098,6 +1104,13 @@ address InterpreterGenerator::generate_native_entry(bool synchronized) {
   __ maybe_isb();
   __ get_method(rmethod);
   // result potentially in r0 or v0
+
+  // when we get back from native c++ code, our coroutine may be stolen by another thread.
+  if (EnableCoroutine) {
+    // it is a little hard to present method signature check here: because interpreter
+    // will directly jump into this entry, which is in runtime.
+    WISP_CALLING_CONVENTION_V2j_UPDATE;
+  }
 
   // make room for the pushes we're about to do
   __ sub(rscratch1, esp, 4 * wordSize);
@@ -1902,11 +1915,31 @@ void TemplateInterpreterGenerator::generate_throw_exception() {
 
   // preserve exception over this code sequence
   __ pop_ptr(r0);
-  __ str(r0, Address(rthread, JavaThread::vm_result_offset()));
+  if (EnableCoroutine && UseWispMonitor) {
+    /**
+     * this fix is added here due to the fact that this function may call back to java(at _monitorexit when UseWispMonitor is enabled)
+     * Generally, _monitorexit is invoked by: 1. _return bytecode 2. when exception happens, 3. normally unlock an object.
+     * 1 and 2 will call remove_activation to force unwinding current stack and go up to the caller.
+     * When exception happens, the program will run to: _remove_activation_entry and then remove_activation.
+     * they will both get here while facing race condition.
+     * Only when 2 happens, hotspot will save the exception oop into rax, then call remove_activation.
+     * But because remove_activation possibly use rax, it hence saves rax (exception oop) to thread->_vm_result temporarily.
+     * It won't see the problem in the normal case because _monitorexit won't call to java(the original vm code impl. does get chance to modify _vm_result)
+     * Because of the call back to java required by Wisp impl. at _monitorexit which in turn may modify _vm_result,
+     * The current fix MUST to restore the exception oop into different field(_vm_result_for_wisp ).
+     */
+    __ str(r0, Address(rthread, JavaThread::vm_result_for_wisp_offset()));
+  } else {
+    __ str(r0, Address(rthread, JavaThread::vm_result_offset()));
+  }
   // remove the activation (without doing throws on illegalMonitorExceptions)
   __ remove_activation(vtos, false, true, false);
   // restore exception
-  __ get_vm_result(r0, rthread);
+  if (EnableCoroutine && UseWispMonitor) {
+    __ get_vm_result_for_wisp(r0, rthread);
+  } else {
+    __ get_vm_result(r0, rthread);
+  }
 
   // In between activations - previous activation type unknown yet
   // compute continuation point - the continuation point expects the

--- a/src/share/vm/runtime/coroutine.cpp
+++ b/src/share/vm/runtime/coroutine.cpp
@@ -38,6 +38,9 @@
 #ifdef TARGET_ARCH_zero
 # include "vmreg_zero.inline.hpp"
 #endif
+#ifdef TARGET_ARCH_aarch64
+# include "vmreg_aarch64.inline.hpp"
+#endif
 
 
 #ifdef _WINDOWS
@@ -143,10 +146,8 @@ Coroutine* Coroutine::create_coroutine(JavaThread* thread, CoroutineStack* stack
   jobject obj = JNIHandles::make_global(coroutineObj);
 
   intptr_t** d = (intptr_t**)stack->stack_base();
-#ifndef AARCH64
-  // FIXME wisp on aarch64
   set_coroutine_base(d, thread, obj, coro, coroutineObj, (address)coroutine_start);
-#endif
+
   stack->set_last_sp((address) d);
 
   coro->_state = _created;
@@ -466,10 +467,7 @@ void CoroutineStack::frames_do(FrameClosure* fc) {
   // see comments in `frame::sender()`
   // if the sender is a compiler frame, we cannot assume its value.
   StackFrameStream fst(_thread, fr);
-#ifndef AARCH64
-  // FIXME wisp on AARCH64
   fst.register_map()->set_location(get_fp_reg()->as_VMReg(), (address)_last_sp);
-#endif
   fst.register_map()->set_include_argument_oops(false);
   for(; !fst.is_done(); fst.next()) {
     fc->frames_do(fst.current(), fst.register_map());
@@ -482,10 +480,7 @@ frame CoroutineStack::last_frame(Coroutine* coro, RegisterMap& map) const {
   intptr_t* fp = ((intptr_t**)_last_sp)[0];
   address pc = ((address*)_last_sp)[1];
   intptr_t* sp = ((intptr_t*)_last_sp) + 2;
-#ifndef AARCH64
-  // FIXME wisp on AARCH64
   map.set_location(get_fp_reg()->as_VMReg(), (address)_last_sp);
-#endif
   map.set_include_argument_oops(false);
 
   frame f(sp, fp, pc);

--- a/src/share/vm/runtime/coroutine.hpp
+++ b/src/share/vm/runtime/coroutine.hpp
@@ -524,6 +524,9 @@ public:
 #ifdef TARGET_ARCH_x86
 # include "coroutine_x86.hpp"
 #endif
+#ifdef TARGET_ARCH_aarch64
+# include "coroutine_aarch64.hpp"
+#endif
 #define WISP_THREAD_UPDATE get_thread(R_TH)
 #define WISP_CALLING_CONVENTION_V2J_UPDATE __ WISP_THREAD_UPDATE
 #define WISP_CALLING_CONVENTION_V2j_UPDATE __ WISP_THREAD_UPDATE


### PR DESCRIPTION
Summary: Support AArch64 platform for Wisp based on the latest AArch64 port

Test Plan: all wisp tests on AArch64 platform

Reviewed-by: leiyul, sandlerwang

Issue: alibaba/dragonwell8#233