### PR TITLE
[JFR] Fix object profiling stacktrace problem on aarch64 platform

### DIFF
--- a/src/share/vm/jfr/jni/jfrJniMethod.cpp
+++ b/src/share/vm/jfr/jni/jfrJniMethod.cpp
@@ -258,7 +258,7 @@ JVM_ENTRY_NO_ENV(jlong, jfr_class_id(JNIEnv* env, jclass jvm, jclass jc))
 JVM_END
 
 JVM_ENTRY_NO_ENV(jlong, jfr_stacktrace_id(JNIEnv* env, jobject jvm, jint skip))
-  return JfrStackTraceRepository::record(thread, skip, WALK_BY_DEFAULT);
+  return JfrStackTraceRepository::record(thread, skip);
 JVM_END
 
 JVM_ENTRY_NO_ENV(void, jfr_log(JNIEnv* env, jobject jvm, jint tag_set, jint level, jstring message))

--- a/src/share/vm/jfr/leakprofiler/sampling/objectSampler.cpp
+++ b/src/share/vm/jfr/leakprofiler/sampling/objectSampler.cpp
@@ -121,7 +121,7 @@ static traceid get_thread_id(JavaThread* thread) {
 static void record_stacktrace(JavaThread* thread) {
   assert(thread != NULL, "invariant");
   if (JfrEventSetting::has_stacktrace(EventOldObjectSample::eventId)) {
-    JfrStackTraceRepository::record_and_cache(thread, 0, WALK_BY_DEFAULT);
+    JfrStackTraceRepository::record_and_cache(thread, 0);
   }
 }
 

--- a/src/share/vm/jfr/recorder/jfrEventSetting.cpp
+++ b/src/share/vm/jfr/recorder/jfrEventSetting.cpp
@@ -54,14 +54,6 @@ void JfrEventSetting::set_enabled(jlong id, bool enabled) {
   setting(event_id).enabled = enabled;
 }
 
-StackWalkMode JfrEventSetting::stack_walk_mode(JfrEventId event_id) {
-  if (event_id == JfrOptoArrayObjectAllocationEvent ||
-      event_id == JfrOptoInstanceObjectAllocationEvent) {
-    return WALK_BY_CURRENT_FRAME;
-  }
-  return WALK_BY_DEFAULT;
-}
-
 #ifdef ASSERT
 bool JfrEventSetting::bounds_check_event(jlong id) {
   if ((unsigned)id < NUM_RESERVED_EVENTS || (unsigned)id >= MaxJfrEventId) {

--- a/src/share/vm/jfr/recorder/jfrEventSetting.hpp
+++ b/src/share/vm/jfr/recorder/jfrEventSetting.hpp
@@ -47,7 +47,6 @@ class JfrEventSetting : AllStatic {
   static jlong threshold(JfrEventId event_id);
   static bool set_cutoff(jlong event_id, jlong cutoff_ticks);
   static jlong cutoff(JfrEventId event_id);
-  static StackWalkMode stack_walk_mode(JfrEventId event_id);
   DEBUG_ONLY(static bool bounds_check_event(jlong id);)
 };
 

--- a/src/share/vm/jfr/recorder/service/jfrEvent.hpp
+++ b/src/share/vm/jfr/recorder/service/jfrEvent.hpp
@@ -177,7 +177,7 @@ class JfrEvent {
         if (tl->has_cached_stack_trace()) {
           writer.write(tl->cached_stack_trace_id());
         } else {
-          writer.write(JfrStackTraceRepository::record(event_thread, 0, JfrEventSetting::stack_walk_mode(T::eventId)));
+          writer.write(JfrStackTraceRepository::record(event_thread, 0));
         }
       } else {
         writer.write<traceid>(0);

--- a/src/share/vm/jfr/recorder/stacktrace/jfrStackTrace.hpp
+++ b/src/share/vm/jfr/recorder/stacktrace/jfrStackTrace.hpp
@@ -34,15 +34,6 @@ class JfrCheckpointWriter;
 class JfrChunkWriter;
 class Method;
 
-enum StackWalkMode {
-  // walk stack by vframeStream vfs(thread).
-  WALK_BY_DEFAULT = 0,
-  // walk stack by vframeStream vfs(thread, os::current_frame()).
-  // It is only used in JIT runtime leaf call. In JIT runtime leaf call,
-  // last_java_sp is not maintained and WALK_BY_DEFAULT can not walk stack.
-  WALK_BY_CURRENT_FRAME
-};
-
 class JfrStackFrame {
   friend class ObjectSampleCheckpoint;
  private:
@@ -103,7 +94,7 @@ class JfrStackTrace : public JfrCHeapObj {
   void resolve_linenos() const;
 
   bool record_thread(JavaThread& thread, frame& frame);
-  bool record_safe(JavaThread* thread, int skip, StackWalkMode stack_walk_mode);
+  bool record_safe(JavaThread* thread, int skip);
 
   bool have_lineno() const { return _lineno; }
   bool full_stacktrace() const { return _reached_root; }
@@ -112,7 +103,7 @@ class JfrStackTrace : public JfrCHeapObj {
   JfrStackTrace(JfrStackFrame* frames, u4 max_frames);
   ~JfrStackTrace();
 
-  bool fill_in(vframeStream& vfs, int skip, StackWalkMode mode);
+  bool fill_in(vframeStream& vfs, int skip);
  public:
   unsigned int hash() const { return _hash; }
   traceid id() const { return _id; }

--- a/src/share/vm/jfr/recorder/stacktrace/jfrStackTraceRepository.cpp
+++ b/src/share/vm/jfr/recorder/stacktrace/jfrStackTraceRepository.cpp
@@ -125,7 +125,7 @@ size_t JfrStackTraceRepository::clear() {
   return processed;
 }
 
-traceid JfrStackTraceRepository::record(Thread* thread, int skip, StackWalkMode mode) {
+traceid JfrStackTraceRepository::record(Thread* thread, int skip) {
   assert(thread == Thread::current(), "invariant");
   JfrThreadLocal* const tl = thread->jfr_thread_local();
   assert(tl != NULL, "invariant");
@@ -142,12 +142,12 @@ traceid JfrStackTraceRepository::record(Thread* thread, int skip, StackWalkMode 
   }
   assert(frames != NULL, "invariant");
   assert(tl->stackframes() == frames, "invariant");
-  return instance().record_for((JavaThread*)thread, skip, mode, frames, tl->stackdepth());
+  return instance().record_for((JavaThread*)thread, skip, frames, tl->stackdepth());
 }
 
-traceid JfrStackTraceRepository::record_for(JavaThread* thread, int skip, StackWalkMode mode, JfrStackFrame *frames, u4 max_frames) {
+traceid JfrStackTraceRepository::record_for(JavaThread* thread, int skip, JfrStackFrame *frames, u4 max_frames) {
   JfrStackTrace stacktrace(frames, max_frames);
-  return stacktrace.record_safe(thread, skip, mode) ? add(stacktrace) : 0;
+  return stacktrace.record_safe(thread, skip) ? add(stacktrace) : 0;
 }
 
 traceid JfrStackTraceRepository::add(const JfrStackTrace& stacktrace) {
@@ -160,13 +160,13 @@ traceid JfrStackTraceRepository::add(const JfrStackTrace& stacktrace) {
   return tid;
 }
 
-void JfrStackTraceRepository::record_and_cache(JavaThread* thread, int skip, StackWalkMode mode) {
+void JfrStackTraceRepository::record_and_cache(JavaThread* thread, int skip) {
   assert(thread != NULL, "invariant");
   JfrThreadLocal* const tl = thread->jfr_thread_local();
   assert(tl != NULL, "invariant");
   assert(!tl->has_cached_stack_trace(), "invariant");
   JfrStackTrace stacktrace(tl->stackframes(), tl->stackdepth());
-  stacktrace.record_safe(thread, skip, mode);
+  stacktrace.record_safe(thread, skip);
   const unsigned int hash = stacktrace.hash();
   if (hash != 0) {
     tl->set_cached_stack_trace_id(instance().add(stacktrace), hash);

--- a/src/share/vm/jfr/recorder/stacktrace/jfrStackTraceRepository.hpp
+++ b/src/share/vm/jfr/recorder/stacktrace/jfrStackTraceRepository.hpp
@@ -63,11 +63,11 @@ class JfrStackTraceRepository : public JfrCHeapObj {
 
   traceid add_trace(const JfrStackTrace& stacktrace);
   static traceid add(const JfrStackTrace& stacktrace);
-  traceid record_for(JavaThread* thread, int skip, StackWalkMode mode, JfrStackFrame* frames, u4 max_frames);
+  traceid record_for(JavaThread* thread, int skip, JfrStackFrame* frames, u4 max_frames);
 
  public:
-  static traceid record(Thread* thread, int skip, StackWalkMode mode);
-  static void record_and_cache(JavaThread* thread, int skip, StackWalkMode mode);
+  static traceid record(Thread* thread, int skip);
+  static void record_and_cache(JavaThread* thread, int skip);
 };
 
 #endif // SHARE_JFR_RECORDER_STACKTRACE_JFRSTACKTRACEREPOSITORY_HPP

--- a/src/share/vm/jfr/support/jfrFlush.cpp
+++ b/src/share/vm/jfr/support/jfrFlush.cpp
@@ -70,12 +70,12 @@ void jfr_conditional_flush(JfrEventId id, size_t size, Thread* t) {
   }
 }
 
-bool jfr_save_stacktrace(Thread* t, StackWalkMode mode) {
+bool jfr_save_stacktrace(Thread* t) {
   JfrThreadLocal* const tl = t->jfr_thread_local();
   if (tl->has_cached_stack_trace()) {
     return false; // no ownership
   }
-  tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(t, 0, mode));
+  tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(t, 0));
   return true;
 }
 

--- a/src/share/vm/jfr/support/jfrFlush.hpp
+++ b/src/share/vm/jfr/support/jfrFlush.hpp
@@ -45,7 +45,7 @@ class JfrFlush : public StackObj {
 void jfr_conditional_flush(JfrEventId id, size_t size, Thread* t);
 bool jfr_is_event_enabled(JfrEventId id);
 bool jfr_has_stacktrace_enabled(JfrEventId id);
-bool jfr_save_stacktrace(Thread* t, StackWalkMode mode);
+bool jfr_save_stacktrace(Thread* t);
 void jfr_clear_stacktrace(Thread* t);
 
 template <typename Event>
@@ -68,7 +68,7 @@ class JfrConditionalFlushWithStacktrace : public JfrConditionalFlush<Event> {
  public:
   JfrConditionalFlushWithStacktrace(Thread* t) : JfrConditionalFlush<Event>(t), _t(t), _owner(false) {
     if (this->_enabled && Event::has_stacktrace() && jfr_has_stacktrace_enabled(Event::eventId)) {
-      _owner = jfr_save_stacktrace(t, JfrEventSetting::stack_walk_mode(Event::eventId));
+      _owner = jfr_save_stacktrace(t);
     }
   }
   ~JfrConditionalFlushWithStacktrace() {

--- a/src/share/vm/jfr/support/jfrStackTraceMark.cpp
+++ b/src/share/vm/jfr/support/jfrStackTraceMark.cpp
@@ -36,7 +36,7 @@ JfrStackTraceMark::JfrStackTraceMark() : _t(Thread::current()), _previous_id(0),
     _previous_id = tl->cached_stack_trace_id();
     _previous_hash = tl->cached_stack_trace_hash();
   }
-  tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(Thread::current(), 0, WALK_BY_DEFAULT));
+  tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(Thread::current(), 0));
 }
 
 JfrStackTraceMark::JfrStackTraceMark(Thread* t) : _t(t), _previous_id(0), _previous_hash(0) {
@@ -45,7 +45,7 @@ JfrStackTraceMark::JfrStackTraceMark(Thread* t) : _t(t), _previous_id(0), _previ
     _previous_id = tl->cached_stack_trace_id();
     _previous_hash = tl->cached_stack_trace_hash();
   }
-  tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(t, 0, WALK_BY_DEFAULT));
+  tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(t, 0));
 }
 
 JfrStackTraceMark::JfrStackTraceMark(JfrEventId eventId) : _t(NULL), _previous_id(0), _previous_hash(0) {
@@ -56,8 +56,7 @@ JfrStackTraceMark::JfrStackTraceMark(JfrEventId eventId) : _t(NULL), _previous_i
       _previous_id = tl->cached_stack_trace_id();
       _previous_hash = tl->cached_stack_trace_hash();
     }
-    StackWalkMode mode = JfrEventSetting::stack_walk_mode(eventId);
-    tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(_t, 0, mode));
+    tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(_t, 0));
   }
 }
 
@@ -69,8 +68,7 @@ JfrStackTraceMark::JfrStackTraceMark(JfrEventId eventId, Thread* t) : _t(NULL), 
       _previous_id = tl->cached_stack_trace_id();
       _previous_hash = tl->cached_stack_trace_hash();
     }
-    StackWalkMode mode = JfrEventSetting::stack_walk_mode(eventId);
-    tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(_t, 0, mode));
+    tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(_t, 0));
   }
 }
 

--- a/src/share/vm/jfr/support/jfrThreadLocal.cpp
+++ b/src/share/vm/jfr/support/jfrThreadLocal.cpp
@@ -57,7 +57,6 @@ JfrThreadLocal::JfrThreadLocal() :
   _entering_suspend_flag(0),
   _excluded(false),
   _dead(false),
-  _cached_top_frame_bci(max_jint),
   _alloc_count(0),
   _alloc_count_until_sample(1),
   _cached_event_id(MaxJfrEventId) {

--- a/src/share/vm/jfr/support/jfrThreadLocal.hpp
+++ b/src/share/vm/jfr/support/jfrThreadLocal.hpp
@@ -53,18 +53,6 @@ class JfrThreadLocal {
   bool _excluded;
   bool _dead;
   traceid _parent_trace_id;
-  // Jfr callstack collection relies on vframeStream.
-  // But the bci of top frame can not be determined by vframeStream in some scenarios.
-  // For example, in the opto CallLeafNode runtime call of
-  // OptoRuntime::jfr_fast_object_alloc_C, the top frame bci
-  // returned by vframeStream is always invalid. This is largely due to the oopmap that
-  // is not correctly granted ( refer to PhaseMacroExpand::expand_allocate_common to get more details ).
-  // The opto fast path object allocation tracing occurs in the opto CallLeafNode,
-  // which has been broken by invalid top frame bci.
-  // To fix this, we get the top frame bci in opto compilation phase
-  // and pass it as parameter to runtime call. Our implementation will replace the invalid top
-  // frame bci with cached_top_frame_bci.
-  jint _cached_top_frame_bci;
   jlong _alloc_count;
   jlong _alloc_count_until_sample;
   // This field is used to help to distinguish the object allocation request source.
@@ -236,22 +224,6 @@ class JfrThreadLocal {
 
   bool is_dead() const {
     return _dead;
-  }
-
-  void set_cached_top_frame_bci(jint bci) {
-    _cached_top_frame_bci = bci;
-  }
-
-  bool has_cached_top_frame_bci() const {
-    return _cached_top_frame_bci != max_jint;
-  }
-
-  jint cached_top_frame_bci() const {
-    return _cached_top_frame_bci;
-  }
-
-  void clear_cached_top_frame_bci() {
-    _cached_top_frame_bci = max_jint;
   }
 
   jlong alloc_count() const {

--- a/src/share/vm/opto/macro.hpp
+++ b/src/share/vm/opto/macro.hpp
@@ -106,7 +106,7 @@ private:
   void expand_unlock_node(UnlockNode *unlock);
 
   int replace_input(Node *use, Node *oldref, Node *newref);
-  void copy_call_debug_info(CallNode *oldcall, CallNode * newcall);
+  void copy_call_debug_info(CallNode *oldcall, CallNode * newcall, bool clone_jvms = false);
   Node* opt_bits_test(Node* ctrl, Node* region, int edge, Node* word, int mask, int bits, bool return_fast_path = false);
   void copy_predefined_input_for_runtime_call(Node * ctrl, CallNode* oldcall, CallNode* call);
   CallNode* make_slow_call(CallNode *oldcall, const TypeFunc* slow_call_type, address slow_call,

--- a/src/share/vm/opto/runtime.hpp
+++ b/src/share/vm/opto/runtime.hpp
@@ -143,6 +143,7 @@ class OptoRuntime : public AllStatic {
 
   static address _slow_arraycopy_Java;
   static address _register_finalizer_Java;
+  static address _jfr_fast_object_alloc_Java;
 
 # ifdef ENABLE_ZAP_DEAD_LOCALS
   static address _zap_dead_Java_locals_Java;
@@ -183,7 +184,7 @@ public:
   static void complete_wisp_proxy_monitor_unlocking_C(oopDesc* obj, BasicLock* lock);
 
   // JFR support
-  static void jfr_fast_object_alloc_C(oopDesc* obj, jint bci, JavaThread* thread);
+  static void jfr_fast_object_alloc_C(oopDesc* obj, JavaThread* thread);
 private:
 
   // Implicit exception support
@@ -246,7 +247,7 @@ private:
   static address complete_wisp_monitor_unlocking_Java()  { return _complete_wisp_monitor_unlocking_Java;   }
   static address slow_arraycopy_Java()                   { return _slow_arraycopy_Java; }
   static address register_finalizer_Java()               { return _register_finalizer_Java; }
-
+  static address jfr_fast_object_alloc_Java()            { return _jfr_fast_object_alloc_Java; }
 
 # ifdef ENABLE_ZAP_DEAD_LOCALS
   static address zap_dead_locals_stub(bool is_native)    { return is_native

--- a/src/share/vm/prims/jvm.cpp
+++ b/src/share/vm/prims/jvm.cpp
@@ -3247,7 +3247,7 @@ JVM_ENTRY(void, JVM_StartThread(JNIEnv* env, jobject jthread))
       EventThreadStart::is_stacktrace_enabled()) {
     JfrThreadLocal* tl = native_thread->jfr_thread_local();
     // skip Thread.start() and Thread.start0()
-    tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(thread, 2, WALK_BY_DEFAULT));
+    tl->set_cached_stack_trace_id(JfrStackTraceRepository::record(thread, 2));
   }
 #endif
 


### PR DESCRIPTION
Summary:
1. Use CallStaticJavaNode to invoke jfr_fast_object_alloc_C so that
last_java_sp is set properly
2. Remove StackWalkMode and _cached_top_frame_bci

Test Plan:
test/jdk/jfr/event/objectsprofiling/TestOptoObjectAllocationsSampling.java

Reviewed-by: kelthuzadx, kuaiwei, sandlerwang, zhengxiaolinX

Issue: https://github.com/alibaba/dragonwell11/issues/189