### PR TITLE
[JFR] A wrong parameter is passed to the constructor of LeakKlassWriter

### DIFF
--- a/src/share/vm/jfr/recorder/checkpoint/types/jfrTypeSet.cpp
+++ b/src/share/vm/jfr/recorder/checkpoint/types/jfrTypeSet.cpp
@@ -300,7 +300,7 @@ static bool write_klasses() {
     _subsystem_callback = &callback;
     do_klasses();
   } else {
-    LeakKlassWriter lkw(_leakp_writer, _artifacts, _class_unload);
+    LeakKlassWriter lkw(_leakp_writer, _class_unload);
     CompositeKlassWriter ckw(&lkw, &kw);
     CompositeKlassWriterRegistration ckwr(&ckw, &reg);
     CompositeKlassCallback callback(&ckwr);


### PR DESCRIPTION
Summary: remove the wrong parameter

Test Plan: jtreg jdk/jfr

Reviewed-by: kelthuzadx, joeyleeeeeee97, yuleil

Issue: https://github.com/alibaba/dragonwell8/issues/296